### PR TITLE
fix(ci): drop missing iptv_tv_screen_test.dart from TV release gate

### DIFF
--- a/.github/workflows/airo-tv-release.yml
+++ b/.github/workflows/airo-tv-release.yml
@@ -481,7 +481,7 @@ jobs:
           flutter test test/core/app/tv_router_test.dart test/main_tv_debug_playlist_test.dart --reporter=compact
           cd ../packages/feature_iptv
           flutter analyze lib test --no-fatal-infos --no-fatal-warnings
-          flutter test test/iptv/presentation/screens/iptv_screen_test.dart test/iptv/presentation/tv/iptv_tv_screen_test.dart test/iptv/iptv_cast_ui_test.dart test/iptv/iptv_cast_notifier_test.dart --reporter=compact
+          flutter test test/iptv/presentation/screens/iptv_screen_test.dart test/iptv/iptv_cast_ui_test.dart test/iptv/iptv_cast_notifier_test.dart --reporter=compact
           cd ../platform_media
           flutter analyze lib/src/local_media_library.dart lib/src/video_player_airo_playback_engine.dart test/local_media_library_test.dart --no-fatal-infos --no-fatal-warnings
           flutter test test/local_media_library_test.dart test/video_player_airo_playback_engine_test.dart --reporter=compact


### PR DESCRIPTION
## Summary
- `.github/workflows/airo-tv-release.yml`'s release quality gate ran `flutter test` against `packages/feature_iptv/test/iptv/presentation/tv/iptv_tv_screen_test.dart`, which no longer exists — the gate failed before Android TV APK/AAB build could run.
- Failing run: https://github.com/DevelopersCoffee/airo/actions/runs/33835088139
- Removed only that missing path from the `flutter test` line. `iptv_screen_test.dart`, `iptv_cast_ui_test.dart`, and `iptv_cast_notifier_test.dart` are unchanged and confirmed present.

## Not touched
- No package IDs, dart-defines, or Play track changes.

## Test plan
- [ ] Re-run `airo-tv-release.yml` and confirm the quality-gates step passes past this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)