### PR TITLE
docs(aika-stream): refresh capability matrix, XR-inspired hero glow

### DIFF
--- a/docs/aika-stream/index.html
+++ b/docs/aika-stream/index.html
@@ -635,10 +635,39 @@
             </article>
             <article class="capability-item">
               <span class="status status-available">Available</span>
-              <h3>XMLTV guide and playback diagnostics</h3>
+              <h3>XMLTV guide and reminders</h3>
               <p>
-                Add an authorized XMLTV source and receive bounded, clearer
-                playback-recovery states.
+                Add an authorized XMLTV source, jump to what's on now, and set
+                program reminders.
+              </p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-available">Available</span>
+              <h3>Multiple source types</h3>
+              <p>
+                M3U, Xtream, Stalker, and Jellyfin sources side by side, switched
+                and refreshed from Settings.
+              </p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-available">Available</span>
+              <h3>Multi-track audio and subtitles</h3>
+              <p>
+                Switch audio and subtitle tracks per stream from the player's
+                track menu.
+              </p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-available">Available</span>
+              <h3>Playback speed and aspect ratio</h3>
+              <p>Adjust speed and aspect ratio from Settings and the player.</p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-available">Available</span>
+              <h3>Codec and stream diagnostics</h3>
+              <p>
+                An on-screen stats overlay shows codec, resolution, and bitrate
+                for the active stream.
               </p>
             </article>
             <article class="capability-item">
@@ -646,6 +675,22 @@
               <h3>Recording and cloud playlists</h3>
               <p>
                 Aika Stream does not record and does not run cloud playlist storage.
+              </p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-planned">Not on TV yet</span>
+              <h3>Cast, Picture-in-Picture, downloads</h3>
+              <p>
+                Available on the phone build; not yet part of the TV release
+                profile.
+              </p>
+            </article>
+            <article class="capability-item">
+              <span class="status status-planned">Not supported</span>
+              <h3>Profiles, app lock, incognito</h3>
+              <p>
+                Multi-profile restrictions, a PIN/biometric app lock, and an
+                incognito viewing mode are not built yet.
               </p>
             </article>
           </div>

--- a/docs/assets/airo-tv/site.css
+++ b/docs/assets/airo-tv/site.css
@@ -314,6 +314,27 @@ button,
   overflow: hidden;
   border-bottom: 1px solid var(--border);
   isolation: isolate;
+  --pointer-x: 50%;
+  --pointer-y: 38%;
+}
+
+.hero-glow {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: radial-gradient(
+    480px circle at var(--pointer-x) var(--pointer-y),
+    color-mix(in oklch, var(--green), transparent 84%),
+    transparent 60%
+  );
+  opacity: 0;
+  transition: opacity 420ms ease;
+  pointer-events: none;
+}
+
+.hero:hover .hero-glow,
+.hero.has-pointer .hero-glow {
+  opacity: 1;
 }
 
 .hero-media {
@@ -552,6 +573,9 @@ button,
     linear-gradient(color-mix(in oklch, var(--green-soft), transparent 46%) 1px, transparent 1px) 0 0 / 16px 16px,
     var(--surface);
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.28);
+  transform: perspective(1200px) rotateX(var(--tilt-x, 0deg)) rotateY(var(--tilt-y, 0deg));
+  transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: transform;
 }
 
 .hero-preview-board-head,

--- a/docs/assets/airo-tv/site.js
+++ b/docs/assets/airo-tv/site.js
@@ -150,6 +150,54 @@
     }
   }
 
+  const heroes = document.querySelectorAll(".hero");
+  const finePointer = window.matchMedia("(pointer: fine)").matches;
+
+  if (!reducedMotion && finePointer && heroes.length) {
+    heroes.forEach(function (hero) {
+      const glow = document.createElement("div");
+      glow.className = "hero-glow";
+      glow.setAttribute("aria-hidden", "true");
+      hero.prepend(glow);
+
+      const board = hero.querySelector(".hero-preview-board");
+      let pointerFrameRequested = false;
+      let lastEvent = null;
+
+      function applyPointer() {
+        pointerFrameRequested = false;
+        if (!lastEvent) return;
+        const rect = hero.getBoundingClientRect();
+        const x = ((lastEvent.clientX - rect.left) / rect.width) * 100;
+        const y = ((lastEvent.clientY - rect.top) / rect.height) * 100;
+        hero.style.setProperty("--pointer-x", x + "%");
+        hero.style.setProperty("--pointer-y", y + "%");
+        if (board) {
+          const tiltY = ((x - 50) / 50) * 4;
+          const tiltX = ((50 - y) / 50) * 3;
+          board.style.setProperty("--tilt-y", tiltY + "deg");
+          board.style.setProperty("--tilt-x", tiltX + "deg");
+        }
+      }
+
+      hero.addEventListener("pointermove", function (event) {
+        lastEvent = event;
+        hero.classList.add("has-pointer");
+        if (pointerFrameRequested) return;
+        pointerFrameRequested = true;
+        window.requestAnimationFrame(applyPointer);
+      });
+
+      hero.addEventListener("pointerleave", function () {
+        hero.classList.remove("has-pointer");
+        if (board) {
+          board.style.setProperty("--tilt-x", "0deg");
+          board.style.setProperty("--tilt-y", "0deg");
+        }
+      });
+    });
+  }
+
   const liveDemoInstances = [];
 
   function initializeLiveDemo(root) {


### PR DESCRIPTION
## Summary
- Capability matrix on the public Aika Stream page now lists only TV-verified features (multi-track audio/subtitles, playback speed/aspect ratio, codec diagnostics, guide + reminders, multi-source Xtream/M3U/Stalker/Jellyfin) and calls out Cast picker/PiP/downloads as phone-only rather than implying general availability. Full gap list (family profiles, app lock, incognito, delay sync, chapters, home customization, etc.) tracked in #1955.
- Added a pointer-reactive glow + subtle parallax tilt to the hero preview board, taking inspiration from android.com/xr's cursor-driven motion. Pure CSS/JS, gated on `pointer: fine` and `prefers-reduced-motion`, no new dependency, no layout change on touch/mobile.
- No competitor is named anywhere on the page, consistent with the legal revert of the earlier named-comparison pages (#1535).

## Test plan
- [x] Served `docs/` locally, loaded `aika-stream/index.html`, confirmed capability grid renders and copy is accurate
- [x] Confirmed hero pointer glow/tilt activates on hover, resets on pointer leave, no console errors from the change (only unrelated CDN network errors from the sandboxed preview)
- [ ] Reviewer: eyeball on a real desktop pointer + confirm mobile/touch is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)