### PR TITLE
fix(tv): format main_tv.dart to satisfy CI dart format check

### DIFF
--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -91,9 +91,7 @@ void main() {
     composeApp: () async {
       await configureTvSystemChrome();
 
-      debugPrint(
-        '🖥️ Starting Aika Stream (${PlatformFeatures.platformName})',
-      );
+      debugPrint('🖥️ Starting Aika Stream (${PlatformFeatures.platformName})');
       debugPrint(
         '📺 Features: '
         '${PlatformFeatures.enabledFeatures.map((f) => f.name).join(', ')}',


### PR DESCRIPTION
## Summary
- `app/lib/main_tv.dart` was left unformatted after #1954 merged, failing the "Check formatting" step (`analyze` and `code-quality` jobs) on every PR since — including the unrelated docs PR #1956, which merged despite the red check.
- One-line `debugPrint` reflow, produced by `dart format` inside `app/` (project page-width config, matching CI's `cd app && ... dart format --set-exit-if-changed`).

## Test plan
- [x] `cd app && dart format --set-exit-if-changed lib/main_tv.dart` exits 0 after the change
- [x] No behavior change, formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)