### PR TITLE
fix(tv): Aika Stream on phones/tablets + trim ProGuard keeps

### DIFF
--- a/app/android/app/proguard-rules.pro
+++ b/app/android/app/proguard-rules.pro
@@ -72,7 +72,12 @@
 # ============================================
 # AndroidX / Jetpack
 # ============================================
--keep class androidx.** { *; }
+# No blanket keep: every AndroidX artifact ships its own consumer
+# proguard-rules.pro (AGP merges these automatically), and androidx is
+# the single largest package tree Flutter pulls in -- keeping all of it
+# was the main driver of Play Console's low optimization/obfuscation/
+# shrinking scores. -dontwarn stays broad since AndroidX has legitimate
+# optional-dependency warnings across modules we don't all use.
 -dontwarn androidx.**
 
 # Lifecycle
@@ -89,18 +94,6 @@
 -keepclasseswithmembernames class * {
     native <methods>;
 }
-
-# ============================================
-# Audio Players (just_audio, audioplayers)
-# ============================================
--keep class com.google.android.exoplayer2.** { *; }
--dontwarn com.google.android.exoplayer2.**
-
-# ============================================
-# Video Player
-# ============================================
--keep class com.google.android.exoplayer.** { *; }
--dontwarn com.google.android.exoplayer.**
 
 # ============================================
 # Flame Game Engine

--- a/app/android/app/src/tv/AndroidManifest.xml
+++ b/app/android/app/src/tv/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
-    <uses-feature android:name="android.software.leanback" android:required="true"/>
+    <uses-feature android:name="android.software.leanback" android:required="false"/>
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/docs/release/AIKA_STREAM_PLAY_STORE_GATE.md
+++ b/docs/release/AIKA_STREAM_PLAY_STORE_GATE.md
@@ -32,6 +32,7 @@ not rewrite historical Aika Stream evidence under `docs/release/evidence/`.
 | Android package | `com.developerscoffee.tv.midas` |
 | Entrypoint | `app/lib/main_tv.dart` |
 | Pubspec | `app/pubspec_tv.yaml` |
+| Device class | Android TV, Google TV, Fire TV, and Android phone/tablet (`android.software.leanback` set `required="false"` in `app/android/app/src/tv/AndroidManifest.xml`) |
 | Category | Video Players & Editors |
 | Content model | Media player for user-supplied M3U/M3U8 URLs only |
 | First Play dart-defines | **Unset.** Do not pass `IPTV_DATA_PLAYLIST_URL` or `IPTV_DATA_MANIFEST_URL`. Privacy currently names only user-configured XMLTV. |

--- a/docs/release/AIKA_STREAM_STORE_LISTING.md
+++ b/docs/release/AIKA_STREAM_STORE_LISTING.md
@@ -15,8 +15,8 @@ package-ID cutover and human console actions.
 | Product | Aika Stream |
 | Android package ID | `com.developerscoffee.tv.midas` |
 | Entrypoint | `app/lib/main_tv.dart` |
-| Device class | Android TV, Google TV, Fire TV-compatible APK testing |
-| First Play wave | Android TV / Google Play TV track |
+| Device class | Android TV, Google TV, Fire TV-compatible APK testing, plus Android phone/tablet |
+| First Play wave | Android TV / Google Play TV track, expanded to phone/tablet (`android.software.leanback` no longer `required`) |
 | iOS / App Store | Deferred from the first Android publishing wave |
 | Privacy Policy URL | `https://developerscoffee.github.io/airo/legal/privacy-policy/` |
 | Terms URL | `https://developerscoffee.github.io/airo/legal/terms-conditions/` |


### PR DESCRIPTION
## Summary
- Drop `android.software.leanback required="true"` in the tv-flavor manifest so Play stops filtering Aika Stream's listing to TV-only devices; verified build/install/launch on a Pixel 9 phone (correct phone-form UI, form-factor detector picks `mobile`).
- Remove ProGuard keeps that were tanking Play Console's Optimization/Obfuscation/Shrinking scores (all sat at 14%): the blanket `-keep class androidx.** { *; }` (AndroidX AARs already ship their own consumer proguard rules) and two dead legacy ExoPlayer keep blocks (app uses `androidx.media3`, not `com.google.android.exoplayer(2)`).
- Sync device-class scope in `AIKA_STREAM_STORE_LISTING.md` / `AIKA_STREAM_PLAY_STORE_GATE.md`.

## Test plan
- [x] `flutter run` (debug) on Pixel 9 with `-t lib/main_tv.dart --dart-define=APP_VARIANT=tv` — installs, launches, correct phone UI, no crash
- [x] `flutter build apk --release` (same target) — R8 pass succeeds with trimmed keep list, no missing-class build failure
- [x] Installed release APK on Pixel 9 — clean launch, no `ClassNotFoundException`/`NoClassDefFoundError`/FATAL in logcat
- [ ] Play Console re-upload to confirm optimization score improves (needs a human console step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)