### PR TITLE
fix(tv): sync package_info stub build number with pubspec_tv.yaml

### DIFF
--- a/packages/stubs/package_info_plus_stub/lib/package_info_plus.dart
+++ b/packages/stubs/package_info_plus_stub/lib/package_info_plus.dart
@@ -15,7 +15,7 @@ library;
 /// Kept equal to the `version:` field of `app/pubspec_tv.yaml`, which is
 /// `<_stubVersion>+<_stubBuildNumber>`.
 const String _stubVersion = '0.0.1';
-const String _stubBuildNumber = '13';
+const String _stubBuildNumber = '14';
 
 class PackageInfo {
   PackageInfo({


### PR DESCRIPTION
## Summary
- #1958's versionCode bump (`d41e71af`) moved `app/pubspec_tv.yaml` to `0.0.1+14` but left the TV `package_info_plus` stub's hardcoded fallback at `13`. `tv_stub_version_test.dart` exists specifically to catch this drift and is currently failing on `main` because of it (confirmed on the merge commit for #1961's CI run).
- One-line fix: bump the stub's `_stubBuildNumber` to `14` to match.

## Test plan
- [x] `flutter test test/core/tv_stub_version_test.dart` passes locally against the committed (14/14) state

🤖 Generated with [Claude Code](https://claude.com/claude-code)