### PR TITLE
feat(feature_iptv): split view — cast one channel, watch another locally (#1047)

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -10,6 +10,8 @@ import '../../application/iptv_deep_link.dart';
 import '../../application/player_backgrounding_coordinator.dart';
 import '../../application/providers/channel_filters_provider.dart';
 import '../../application/providers/iptv_providers.dart';
+import '../../application/providers/multiview_provider.dart'
+    show multiviewDecoderBudgetProvider;
 import '../../application/wakelock_playback_coordinator.dart';
 import "package:platform_channels/platform_channels.dart";
 import "package:platform_media/platform_media.dart";
@@ -97,6 +99,17 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
   );
   DateTime? _lastFullscreenBackAt;
   Timer? _macosFullscreenSyncTimer;
+
+  /// True while local playback is paused because [_syncLocalPlaybackWithCast]
+  /// paused it for a device that can't sustain a second concurrent decoder.
+  /// Only set true by that guard, so ending the cast session resumes local
+  /// playback solely when this guard was the one that paused it.
+  bool _localPausedForCast = false;
+
+  /// True once the cast-session default mute (see [_playChannel]) has been
+  /// applied for the current cast session, so switching local channels
+  /// mid-session doesn't re-mute a stream the user explicitly unmuted.
+  bool _mutedDefaultAppliedForCast = false;
 
   /// Guards the postFrameCallback below to fire once per fullscreen entry,
   /// not on every rebuild. Live playback rebuilds constantly (buffering,
@@ -423,23 +436,51 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
     _playChannel(channel);
   }
 
+  /// A plain channel tap always targets the local player, whether or not a
+  /// Cast session is active — casting a channel is now a separate, explicit
+  /// action ([_showCastSheet]/[_showWaysToWatch]), not a side effect of
+  /// tapping while connected. See #1047.
   void _playChannel(IPTVChannel channel) {
     final castState = ref.read(iptvCastProvider);
-    if (castState.activeDevice != null) {
-      ref
-          .read(iptvCastProvider.notifier)
-          .castChannelToActiveDevice(
-            channel: channel,
-            selectedQuality: ref
-                .read(iptvStreamingServiceProvider)
-                .currentState
-                .selectedQuality,
-          );
-      ref.read(addToRecentlyWatchedProvider(channel));
+    if (castState.isCasting && !_canRunLocalWhileCasting()) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(
+            content: Text(
+              "This device can't play a second stream while casting.",
+            ),
+          ),
+        );
       return;
     }
 
-    ref.read(iptvStreamingServiceProvider).playChannel(channel);
+    final streaming = ref.read(iptvStreamingServiceProvider);
+    streaming.playChannel(channel);
+    ref.read(addToRecentlyWatchedProvider(channel));
+    _applyCastDefaultMuteIfNeeded(castState, streaming);
+  }
+
+  /// #829 has no admission-control API yet (deferred). Conservative static
+  /// bound in the meantime: reuse the same per-platform decoder budget
+  /// signal MultiView already sizes itself against — a second concurrent
+  /// local decoder (this local stream, on top of the normal single-stream
+  /// budget of 1) is only allowed on devices with headroom for at least 2.
+  bool _canRunLocalWhileCasting() =>
+      ref.read(multiviewDecoderBudgetProvider) >= 2;
+
+  /// Default local playback to muted the first time it starts during a cast
+  /// session, so the user isn't hearing two audio sources at once; the
+  /// existing mute/unmute control is the explicit opt-out.
+  void _applyCastDefaultMuteIfNeeded(
+    IptvCastState castState,
+    VideoPlayerStreamingService streaming,
+  ) {
+    if (!castState.isCasting || _mutedDefaultAppliedForCast) return;
+    _mutedDefaultAppliedForCast = true;
+    if (!streaming.currentState.isMuted) {
+      streaming.toggleMute();
+    }
   }
 
   Future<bool> _playNaturalLanguageQuery(String query) async {
@@ -757,12 +798,27 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
     );
   }
 
+  /// Casting no longer unconditionally pauses local playback (#1047) — it
+  /// only pauses when [_canRunLocalWhileCasting] says this device can't
+  /// sustain the second decoder, and only resumes what it paused.
   void _syncLocalPlaybackWithCast(bool? wasCasting, bool isCasting) {
     final streaming = ref.read(iptvStreamingServiceProvider);
     if (isCasting) {
-      streaming.pause();
-    } else if (wasCasting == true) {
-      streaming.resume();
+      if (_canRunLocalWhileCasting()) {
+        _mutedDefaultAppliedForCast = true;
+        if (!streaming.currentState.isMuted) {
+          streaming.toggleMute();
+        }
+      } else {
+        streaming.pause();
+        _localPausedForCast = true;
+      }
+    } else {
+      if (_localPausedForCast) {
+        streaming.resume();
+      }
+      _localPausedForCast = false;
+      _mutedDefaultAppliedForCast = false;
     }
   }
 
@@ -1115,6 +1171,10 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
   DateTime? _lastFullscreenBackAt;
   Timer? _macosFullscreenSyncTimer;
 
+  /// See _IPTVScreenState's identical fields.
+  bool _localPausedForCast = false;
+  bool _mutedDefaultAppliedForCast = false;
+
   /// See _IPTVScreenState's identical field: guards the postFrameCallback
   /// below to fire once per fullscreen entry, not on every rebuild.
   bool _fullscreenFocusClaimed = false;
@@ -1260,22 +1320,40 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
     _toggleFullscreen();
   }
 
+  /// See _IPTVScreenState's identical method: a plain tap always targets the
+  /// local player now, casting a channel is a separate explicit action.
   void _playChannel(IPTVChannel channel) {
     final castState = ref.read(iptvCastProvider);
-    if (castState.activeDevice != null) {
-      ref
-          .read(iptvCastProvider.notifier)
-          .castChannelToActiveDevice(
-            channel: channel,
-            selectedQuality: ref
-                .read(iptvStreamingServiceProvider)
-                .currentState
-                .selectedQuality,
-          );
+    if (castState.isCasting && !_canRunLocalWhileCasting()) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(
+            content: Text(
+              "This device can't play a second stream while casting.",
+            ),
+          ),
+        );
       return;
     }
 
-    ref.read(iptvStreamingServiceProvider).playChannel(channel);
+    final streaming = ref.read(iptvStreamingServiceProvider);
+    streaming.playChannel(channel);
+    _applyCastDefaultMuteIfNeeded(castState, streaming);
+  }
+
+  bool _canRunLocalWhileCasting() =>
+      ref.read(multiviewDecoderBudgetProvider) >= 2;
+
+  void _applyCastDefaultMuteIfNeeded(
+    IptvCastState castState,
+    VideoPlayerStreamingService streaming,
+  ) {
+    if (!castState.isCasting || _mutedDefaultAppliedForCast) return;
+    _mutedDefaultAppliedForCast = true;
+    if (!streaming.currentState.isMuted) {
+      streaming.toggleMute();
+    }
   }
 
   Future<void> _showPlaylistSheet() async {
@@ -1331,12 +1409,25 @@ class _IPTVScreenBodyState extends ConsumerState<IPTVScreenBody>
     );
   }
 
+  /// See _IPTVScreenState's identical method.
   void _syncLocalPlaybackWithCast(bool? wasCasting, bool isCasting) {
     final streaming = ref.read(iptvStreamingServiceProvider);
     if (isCasting) {
-      streaming.pause();
-    } else if (wasCasting == true) {
-      streaming.resume();
+      if (_canRunLocalWhileCasting()) {
+        _mutedDefaultAppliedForCast = true;
+        if (!streaming.currentState.isMuted) {
+          streaming.toggleMute();
+        }
+      } else {
+        streaming.pause();
+        _localPausedForCast = true;
+      }
+    } else {
+      if (_localPausedForCast) {
+        streaming.resume();
+      }
+      _localPausedForCast = false;
+      _mutedDefaultAppliedForCast = false;
     }
   }
 

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -1,5 +1,7 @@
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 import "package:feature_iptv/application/channel_metadata_enrichment.dart";
+import "package:feature_iptv/application/providers/multiview_provider.dart"
+    show multiviewDecoderBudgetProvider;
 import "package:feature_iptv/feature_iptv.dart";
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/foundation.dart';
@@ -1071,6 +1073,155 @@ void main() {
     expect(playedChannels, hasLength(1));
     expect(playedChannels.single.id, 'news-1');
   });
+
+  group('split view — cast one channel, watch another locally (#1047)', () {
+    const tv = AiroCastDevice(id: 'tv-1', name: 'Sony Bravia');
+
+    testWidgets('a plain channel tap while casting plays it locally instead of '
+        'redirecting to the cast target', (tester) async {
+      final playedChannels = <IPTVChannel>[];
+      final fakeService = _RecordingStreamingService(played: playedChannels);
+      final castNotifier = _MutableCastNotifier();
+
+      await tester.pumpWidget(
+        createWidget(
+          extraOverrides: [
+            iptvStreamingServiceProvider.overrideWith((ref) {
+              ref.onDispose(() => fakeService.dispose());
+              return fakeService;
+            }),
+            multiviewDecoderBudgetProvider.overrideWithValue(2),
+            iptvCastProvider.overrideWith((ref) => castNotifier),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      castNotifier.setCasting(true, device: tv);
+      await tester.pump();
+
+      await activateAppBarAction(tester, 'Search channels');
+      await tester.enterText(find.byType(TextField).last, 'City News');
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(ListTile, 'City News Live'));
+      await tester.pumpAndSettle();
+
+      expect(playedChannels, hasLength(1));
+      expect(playedChannels.single.id, 'news-1');
+      expect(fakeService.calls, isNot(contains('pause')));
+    });
+
+    testWidgets(
+      'a channel tap while casting on a device without decoder headroom '
+      'shows a capacity message and does not start a second local stream',
+      (tester) async {
+        final playedChannels = <IPTVChannel>[];
+        final fakeService = _RecordingStreamingService(played: playedChannels);
+        final castNotifier = _MutableCastNotifier();
+
+        await tester.pumpWidget(
+          createWidget(
+            extraOverrides: [
+              iptvStreamingServiceProvider.overrideWith((ref) {
+                ref.onDispose(() => fakeService.dispose());
+                return fakeService;
+              }),
+              multiviewDecoderBudgetProvider.overrideWithValue(1),
+              iptvCastProvider.overrideWith((ref) => castNotifier),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        castNotifier.setCasting(true, device: tv);
+        await tester.pump();
+
+        await activateAppBarAction(tester, 'Search channels');
+        await tester.enterText(find.byType(TextField).last, 'City News');
+        await tester.pumpAndSettle();
+        await tester.tap(find.widgetWithText(ListTile, 'City News Live'));
+        await tester.pumpAndSettle();
+
+        expect(playedChannels, isEmpty);
+        expect(
+          find.text("This device can't play a second stream while casting."),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'starting a cast session no longer pauses local playback when the '
+      'device has decoder headroom for both',
+      (tester) async {
+        final playedChannels = <IPTVChannel>[];
+        final fakeService = _RecordingStreamingService(played: playedChannels);
+        final castNotifier = _MutableCastNotifier();
+
+        await tester.pumpWidget(
+          createWidget(
+            extraOverrides: [
+              iptvStreamingServiceProvider.overrideWith((ref) {
+                ref.onDispose(() => fakeService.dispose());
+                return fakeService;
+              }),
+              multiviewDecoderBudgetProvider.overrideWithValue(2),
+              iptvCastProvider.overrideWith((ref) => castNotifier),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        castNotifier.setCasting(true, device: tv);
+        await tester.pump();
+
+        expect(fakeService.calls, isNot(contains('pause')));
+        // Default-muted while casting, with a real mute toggle applied.
+        expect(fakeService.calls, contains('toggleMute'));
+        expect(fakeService.currentState.isMuted, isTrue);
+
+        castNotifier.setCasting(false);
+        await tester.pump();
+
+        // Never paused for cast, so ending the session must not resume it.
+        expect(fakeService.calls, isNot(contains('resume')));
+      },
+    );
+
+    testWidgets(
+      'starting a cast session still pauses local playback when the device '
+      'cannot sustain a second decoder, and resumes it when casting ends',
+      (tester) async {
+        final playedChannels = <IPTVChannel>[];
+        final fakeService = _RecordingStreamingService(played: playedChannels);
+        final castNotifier = _MutableCastNotifier();
+
+        await tester.pumpWidget(
+          createWidget(
+            extraOverrides: [
+              iptvStreamingServiceProvider.overrideWith((ref) {
+                ref.onDispose(() => fakeService.dispose());
+                return fakeService;
+              }),
+              multiviewDecoderBudgetProvider.overrideWithValue(1),
+              iptvCastProvider.overrideWith((ref) => castNotifier),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        castNotifier.setCasting(true, device: tv);
+        await tester.pump();
+
+        expect(fakeService.calls, contains('pause'));
+
+        castNotifier.setCasting(false);
+        await tester.pump();
+
+        expect(fakeService.calls, contains('resume'));
+      },
+    );
+  });
 }
 
 FocusNode _focusTvFocusable(WidgetTester tester, Finder root) {
@@ -1094,10 +1245,53 @@ class _RecordingStreamingService extends VideoPlayerStreamingService {
     : super(engine: FakeAiroPlaybackEngine());
 
   final List<IPTVChannel> played;
+  final List<String> calls = [];
+  StreamingState _state = StreamingState();
 
   @override
   Future<void> playChannel(IPTVChannel channel) async {
     played.add(channel);
+  }
+
+  @override
+  StreamingState get currentState => _state;
+
+  @override
+  Future<void> pause() async {
+    calls.add('pause');
+    _state = _state.copyWith(playbackState: PlaybackState.paused);
+  }
+
+  @override
+  Future<void> resume() async {
+    calls.add('resume');
+    _state = _state.copyWith(playbackState: PlaybackState.playing);
+  }
+
+  @override
+  Future<void> toggleMute() async {
+    calls.add('toggleMute');
+    _state = _state.copyWith(isMuted: !_state.isMuted);
+  }
+}
+
+/// Cast notifier a test can drive directly, without a real [AiroCastController]
+/// session, to simulate a cast session starting/ending.
+class _MutableCastNotifier extends IptvCastNotifier {
+  _MutableCastNotifier()
+    : super(
+        controller: FakeAiroCastController(),
+        adapter: const IptvCastMediaAdapter(),
+      );
+
+  void setCasting(bool casting, {AiroCastDevice? device}) {
+    state = state.copyWith(
+      session: casting
+          ? AiroCastSessionSnapshot.connected(
+              device ?? const AiroCastDevice(id: 'tv-1', name: 'Sony Bravia'),
+            )
+          : AiroCastSessionSnapshot.idle(),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- A plain channel tap no longer redirects to the active Cast session — it always targets the local player. Casting a specific channel stays a separate, explicit action (existing cast device picker), unaffected by this change.
- `_syncLocalPlaybackWithCast` no longer unconditionally pauses local playback when a cast session starts; it only pauses on devices that can't sustain a second concurrent decoder, and only resumes what it actually paused.
- Local playback defaults to muted the first time it starts during a cast session (existing mute/unmute control is the explicit opt-out), so a user isn't hearing two audio sources at once.

## Design notes (per [the spec](docs/superpowers/specs/2026-08-10-split-view-cast-and-watch-spec.md))
- **#829 (admission-control API) is still deferred** — there's no real "can this device sustain one more decoder" API yet. Per the spec's explicit fallback ("this feature should not ship without *some* bound, even a conservative static one"), this reuses MultiView's existing per-platform decoder-budget signal (`multiviewDecoderBudgetProvider`): a second local decoder is only allowed on devices with headroom for 2+ (Android/iOS/web, not the 1-budget fuchsia tier). This is a conservative static bound, not the real predictive admission-control the spec leaves as #829's follow-up call.
- Mirror mode (#1048) and any UI/visual design are out of scope, per the spec.

## Test plan
- [x] `flutter analyze` clean on touched files
- [x] New widget tests: plain tap while casting plays locally, capacity-reached message + no second stream on low-budget devices, no-pause/default-mute when budget allows, pause+resume when budget doesn't
- [x] Full `feature_iptv` test suite: 886 passing, 2 pre-existing failures verified identical on unmodified `origin/main` (unrelated: a leak-tracker/native-picture teardown flake and a VOD-resume pump-timer issue)
- [ ] Physical device verification (concurrent local + cast decoder load) — not done in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)