### PR TITLE
fix(tv): MultiView freeze + long-press channel menu + compact chrome

### DIFF
--- a/packages/feature_iptv/lib/application/providers/control_row_visibility_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/control_row_visibility_provider.dart
@@ -23,7 +23,12 @@ class ControlRowVisibilityState {
 
   factory ControlRowVisibilityState.defaults() {
     return ControlRowVisibilityState({
-      for (final row in AiroTvControlRow.values) row: true,
+      for (final row in AiroTvControlRow.values)
+        // Stats is diagnostic/advanced info (codec, resolution, bitrate) —
+        // useful, but not something most viewers need permanently taking up
+        // a row above the grid. Off by default; the settings dialog turns
+        // it back on, and that choice is persisted like any other row.
+        row: row != AiroTvControlRow.stats,
     });
   }
 

--- a/packages/feature_iptv/lib/application/providers/multiview_provider.dart
+++ b/packages/feature_iptv/lib/application/providers/multiview_provider.dart
@@ -152,8 +152,15 @@ final multiviewDecoderBudgetProvider = Provider<int>((ref) {
 final iptvMultiviewSessionFactoryProvider =
     Provider<IptvMultiviewSessionFactory>((ref) {
       return (channel) async {
+        // mixWithOthers: true — this instance shares the device with the
+        // pool's other tiles and possibly the primary player. Without it,
+        // the platform's own exclusive audio-focus handling silently
+        // pauses (freezes) whichever instance loses that fight, and no
+        // amount of promoting it via setAudible() afterward recovers it —
+        // see VideoPlayerStreamingService's `_mixWithOthers` doc comment.
         final service = VideoPlayerStreamingService(
           config: StreamingConfig.live,
+          mixWithOthers: true,
         );
         try {
           await service.initialize();

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -104,6 +104,9 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
     final hasHotbar = ref.watch(hotbarChannelsProvider).isNotEmpty;
     final rowVisibility = ref.watch(controlRowVisibilityProvider);
     final multiview = ref.watch(multiviewProvider);
+    final favoriteChannelIds =
+        ref.watch(favoriteChannelIdsProvider).value ?? const <String>{};
+    final favoriteToggler = ref.read(channelFavoriteTogglerProvider);
     final playbackStats = ref
         .watch(streamingStateProvider)
         .asData
@@ -170,6 +173,8 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
       onMultiviewToggle: widget.showVideoStage
           ? (channel) => _toggleMultiview(context, channel)
           : null,
+      favoriteChannelIds: favoriteChannelIds,
+      onFavoriteToggle: (channel) => favoriteToggler(channel.id),
       onClearFilters: () => ref.read(channelFiltersProvider.notifier).clear(),
     );
     final infoBar = ChannelInfoBar(

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
@@ -30,6 +30,8 @@ class ChannelLibraryGrid extends StatefulWidget {
     this.onVisibleChannelsChanged,
     this.multiviewChannelIds = const {},
     this.onMultiviewToggle,
+    this.favoriteChannelIds = const {},
+    this.onFavoriteToggle,
     this.onClearFilters,
   });
 
@@ -43,6 +45,8 @@ class ChannelLibraryGrid extends StatefulWidget {
   final ValueChanged<List<IPTVChannel>>? onVisibleChannelsChanged;
   final Set<String> multiviewChannelIds;
   final ValueChanged<IPTVChannel>? onMultiviewToggle;
+  final Set<String> favoriteChannelIds;
+  final ValueChanged<IPTVChannel>? onFavoriteToggle;
 
   /// Resets every filter from the "no matches" state. Null hides that
   /// action, leaving the explanation without a shortcut.
@@ -171,6 +175,10 @@ class _ChannelLibraryGridState extends State<ChannelLibraryGrid> {
                             channel.id,
                           ),
                           onMultiviewToggle: widget.onMultiviewToggle,
+                          isFavorite: widget.favoriteChannelIds.contains(
+                            channel.id,
+                          ),
+                          onFavoriteToggle: widget.onFavoriteToggle,
                         ),
                       );
                     },
@@ -262,6 +270,17 @@ class _NoMatchesView extends StatelessWidget {
   }
 }
 
+const Map<ChannelSortColumn, String> _sortColumnLabels = {
+  ChannelSortColumn.name: 'Name',
+  ChannelSortColumn.category: 'Category',
+  ChannelSortColumn.language: 'Language',
+  ChannelSortColumn.country: 'Country',
+  ChannelSortColumn.type: 'Type',
+};
+
+/// One compact trigger instead of four always-visible chips — same four
+/// sort columns, tucked behind a single control that opens on demand
+/// (#compact-tv-chrome) rather than permanently occupying a full row.
 class _LibrarySortRow extends StatelessWidget {
   const _LibrarySortRow({required this.sort, this.onSort});
 
@@ -270,40 +289,76 @@ class _LibrarySortRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget chip(String label, ChannelSortColumn column) {
-      final active = sort.column == column;
-      return Padding(
-        padding: const EdgeInsets.only(right: 8),
-        child: TvFocusable(
-          key: ValueKey('channel-sort-${column.name}'),
-          semanticLabel: 'Sort by $label',
-          onSelect: onSort == null ? null : () => onSort!(column),
-          borderRadius: 8,
-          child: ChoiceChip(
-            label: Text(label),
-            selected: active,
-            avatar: active
-                ? Icon(
-                    sort.ascending ? Icons.arrow_upward : Icons.arrow_downward,
-                    size: 14,
-                  )
-                : null,
-            onSelected: onSort == null ? null : (_) => onSort!(column),
-          ),
-        ),
-      );
-    }
-
+    final label = _sortColumnLabels[sort.column] ?? 'Name';
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: Row(
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: TvFocusable(
+          key: const ValueKey('channel-sort-trigger'),
+          semanticLabel:
+              'Sort by $label, ${sort.ascending ? 'ascending' : 'descending'}',
+          onSelect: onSort == null ? null : () => _showSortSheet(context),
+          borderRadius: 8,
+          child: Material(
+            color: Theme.of(
+              context,
+            ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.72),
+            borderRadius: BorderRadius.circular(8),
+            child: InkWell(
+              borderRadius: BorderRadius.circular(8),
+              onTap: onSort == null ? null : () => _showSortSheet(context),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      sort.ascending
+                          ? Icons.arrow_upward
+                          : Icons.arrow_downward,
+                      size: 16,
+                    ),
+                    const SizedBox(width: 6),
+                    Text('Sort: $label'),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showSortSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      useSafeArea: true,
+      builder: (sheetContext) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            chip('Name', ChannelSortColumn.name),
-            chip('Category', ChannelSortColumn.category),
-            chip('Language', ChannelSortColumn.language),
-            chip('Country', ChannelSortColumn.country),
+            for (final column in ChannelSortColumn.values)
+              ListTile(
+                key: ValueKey('channel-sort-${column.name}'),
+                leading: sort.column == column
+                    ? Icon(
+                        sort.ascending
+                            ? Icons.arrow_upward
+                            : Icons.arrow_downward,
+                      )
+                    : const SizedBox(width: 24),
+                title: Text(_sortColumnLabels[column] ?? column.name),
+                selected: sort.column == column,
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  onSort?.call(column);
+                },
+              ),
           ],
         ),
       ),
@@ -320,6 +375,8 @@ class _ChannelTile extends StatefulWidget {
     this.focusPlayDelay,
     required this.inMultiview,
     this.onMultiviewToggle,
+    required this.isFavorite,
+    this.onFavoriteToggle,
   });
 
   final IPTVChannel channel;
@@ -329,6 +386,8 @@ class _ChannelTile extends StatefulWidget {
   final Duration? focusPlayDelay;
   final bool inMultiview;
   final ValueChanged<IPTVChannel>? onMultiviewToggle;
+  final bool isFavorite;
+  final ValueChanged<IPTVChannel>? onFavoriteToggle;
 
   @override
   State<_ChannelTile> createState() => _ChannelTileState();
@@ -375,6 +434,30 @@ class _ChannelTileState extends State<_ChannelTile> {
     widget.onSelected?.call(widget.channel);
   }
 
+  bool get _hasActions =>
+      widget.onSelected != null ||
+      widget.onMultiviewToggle != null ||
+      widget.onFavoriteToggle != null;
+
+  Future<void> _showActionsMenu(BuildContext context) {
+    return showModalBottomSheet<void>(
+      context: context,
+      useSafeArea: true,
+      builder: (sheetContext) => _ChannelActionsSheet(
+        channel: widget.channel,
+        onPlay: widget.onSelected == null ? null : _selectNow,
+        inMultiview: widget.inMultiview,
+        onMultiviewToggle: widget.onMultiviewToggle == null
+            ? null
+            : () => widget.onMultiviewToggle!(widget.channel),
+        isFavorite: widget.isFavorite,
+        onFavoriteToggle: widget.onFavoriteToggle == null
+            ? null
+            : () => widget.onFavoriteToggle!(widget.channel),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final country = effectiveChannelCountry(widget.channel, widget.metadata);
@@ -392,9 +475,7 @@ class _ChannelTileState extends State<_ChannelTile> {
           logoUrl: widget.channel.effectiveLogoUrl,
           initials: _initialsFor(widget.channel.name),
           onTap: widget.onSelected == null ? null : _selectNow,
-          onLongPress: widget.onMultiviewToggle == null
-              ? null
-              : () => widget.onMultiviewToggle!(widget.channel),
+          onLongPress: _hasActions ? () => _showActionsMenu(context) : null,
           onFocus: _scheduleFocusPlay,
           onUnfocus: _cancelFocusPlay,
         ),
@@ -464,6 +545,88 @@ class _ChannelTileState extends State<_ChannelTile> {
     final trimmed = name.trim();
     if (trimmed.isEmpty) return '?';
     return trimmed.substring(0, 1).toUpperCase();
+  }
+}
+
+/// Long-press menu for a channel tile — the touch equivalent of the grid's
+/// always-visible per-tile split-view toggle, plus favoriting, in one
+/// discoverable place instead of separate small icon targets.
+class _ChannelActionsSheet extends StatelessWidget {
+  const _ChannelActionsSheet({
+    required this.channel,
+    required this.onPlay,
+    required this.inMultiview,
+    required this.onMultiviewToggle,
+    required this.isFavorite,
+    required this.onFavoriteToggle,
+  });
+
+  final IPTVChannel channel;
+  final VoidCallback? onPlay;
+  final bool inMultiview;
+  final VoidCallback? onMultiviewToggle;
+  final bool isFavorite;
+  final VoidCallback? onFavoriteToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    void act(VoidCallback? action) {
+      Navigator.of(context).pop();
+      action?.call();
+    }
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    channel.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (onPlay != null)
+            ListTile(
+              key: const ValueKey('channel-actions-play'),
+              leading: const Icon(Icons.play_arrow),
+              title: const Text('Play'),
+              onTap: () => act(onPlay),
+            ),
+          if (onMultiviewToggle != null)
+            ListTile(
+              key: const ValueKey('channel-actions-multiview'),
+              leading: Icon(
+                inMultiview ? Icons.remove_from_queue : Icons.add_to_queue,
+              ),
+              title: Text(
+                inMultiview ? 'Remove from split view' : 'Add to split view',
+              ),
+              onTap: () => act(onMultiviewToggle),
+            ),
+          if (onFavoriteToggle != null)
+            ListTile(
+              key: const ValueKey('channel-actions-favorite'),
+              leading: Icon(
+                isFavorite ? Icons.favorite : Icons.favorite_border,
+              ),
+              title: Text(
+                isFavorite ? 'Remove from favorites' : 'Add to favorites',
+              ),
+              onTap: () => act(onFavoriteToggle),
+            ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
   }
 }
 

--- a/packages/feature_iptv/test/application/control_row_visibility_provider_test.dart
+++ b/packages/feature_iptv/test/application/control_row_visibility_provider_test.dart
@@ -5,7 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  test('all rows default visible and persist with approved keys', () async {
+  test('every row but stats defaults visible, and toggles persist with '
+      'approved keys', () async {
     SharedPreferences.setMockInitialValues({});
     final preferences = await SharedPreferences.getInstance();
     final container = ProviderContainer(
@@ -15,14 +16,17 @@ void main() {
 
     final initial = container.read(controlRowVisibilityProvider);
     for (final row in AiroTvControlRow.values) {
-      expect(initial.isVisible(row), isTrue);
+      // Stats (codec/resolution/bitrate) is diagnostic detail off by
+      // default so it doesn't cost a permanent row for viewers who never
+      // open settings to turn it on.
+      expect(initial.isVisible(row), row != AiroTvControlRow.stats);
     }
 
     await container
         .read(controlRowVisibilityProvider.notifier)
-        .setVisible(AiroTvControlRow.stats, false);
+        .setVisible(AiroTvControlRow.stats, true);
 
-    expect(preferences.getBool('iptv_row_stats_visible'), isFalse);
+    expect(preferences.getBool('iptv_row_stats_visible'), isTrue);
   });
 
   test('stored row values hydrate on provider construction', () async {

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -183,7 +183,7 @@ void main() {
         findsNothing,
       );
 
-      expect(find.text('Name'), findsOneWidget);
+      expect(find.text('Sort: Name'), findsOneWidget);
       expect(find.text('City News Live'), findsWidgets);
     } finally {
       debugDefaultTargetPlatformOverride = null;
@@ -899,7 +899,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 250));
 
-    expect(find.text('Name'), findsOneWidget);
+    expect(find.text('Sort: Name'), findsOneWidget);
     expect(find.text('City News Live'), findsWidgets);
     expect(find.text('News'), findsWidgets);
     expect(find.text('LIVE'), findsWidgets);

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -2,6 +2,7 @@ import 'package:core_data/core_data.dart';
 import 'package:feature_iptv/application/providers/channel_filters_provider.dart';
 import 'package:feature_iptv/application/providers/channel_auto_scan_providers.dart';
 import 'package:feature_iptv/application/providers/connectivity_provider.dart';
+import 'package:feature_iptv/application/providers/control_row_visibility_provider.dart';
 import 'package:feature_iptv/application/providers/iptv_providers.dart';
 import 'package:feature_iptv/application/services/wifi_settings_launcher.dart';
 import 'package:feature_iptv/presentation/tv_ux/airo_tv_shell.dart';
@@ -230,6 +231,14 @@ void main() {
   testWidgets('stats row shows exact live values and hides without a stream', (
     tester,
   ) async {
+    // The stats row now defaults to hidden (#compact-tv-chrome) — opt back
+    // in via the same SharedPreferences key the real settings toggle
+    // writes, so this test exercises the row's content logic rather than
+    // its default visibility.
+    SharedPreferences.setMockInitialValues({
+      channelCountryPromptCompletedStorageKey: true,
+      AiroTvControlRow.stats.storageKey: true,
+    });
     final playing = StreamingState(
       currentChannel: channels.first,
       playbackState: PlaybackState.playing,

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_library_grid_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_library_grid_test.dart
@@ -23,41 +23,43 @@ void main() {
     ),
   ];
 
-  testWidgets('grid renders every channel as a tile with sort chips', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            width: 800,
-            height: 600,
-            child: ChannelLibraryGrid(
-              channels: channels,
-              metadataByChannelId: {
-                'one': ChannelBrowseMetadata(country: 'IN', language: 'en'),
-                'two': ChannelBrowseMetadata(country: 'US', language: 'en'),
-              },
-              availabilityByChannelId: {
-                'one': StreamAvailability.available,
-                'two': StreamAvailability.unavailable,
-              },
+  testWidgets(
+    'grid renders every channel as a tile with a compact sort trigger',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 600,
+              child: ChannelLibraryGrid(
+                channels: channels,
+                metadataByChannelId: {
+                  'one': ChannelBrowseMetadata(country: 'IN', language: 'en'),
+                  'two': ChannelBrowseMetadata(country: 'US', language: 'en'),
+                },
+                availabilityByChannelId: {
+                  'one': StreamAvailability.available,
+                  'two': StreamAvailability.unavailable,
+                },
+              ),
             ),
           ),
         ),
-      ),
-    );
+      );
 
-    expect(find.text('Name'), findsOneWidget);
-    expect(find.text('Category'), findsOneWidget);
-    expect(find.text('Language'), findsOneWidget);
-    expect(find.text('Country'), findsOneWidget);
-    expect(find.byKey(const ValueKey('channel-tile-one')), findsOneWidget);
-    expect(find.byKey(const ValueKey('channel-tile-two')), findsOneWidget);
-    expect(find.text('One'), findsOneWidget);
-    expect(find.text('ABC'), findsOneWidget);
-    expect(tester.takeException(), isNull);
-  });
+      // One compact "Sort: Name" trigger replaces four always-visible chips
+      // (#compact-tv-chrome) — the other three columns live inside the
+      // sheet it opens, not permanently on screen.
+      expect(find.text('Sort: Name'), findsOneWidget);
+      expect(find.text('Category'), findsNothing);
+      expect(find.byKey(const ValueKey('channel-tile-one')), findsOneWidget);
+      expect(find.byKey(const ValueKey('channel-tile-two')), findsOneWidget);
+      expect(find.text('One'), findsOneWidget);
+      expect(find.text('ABC'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('filtered-to-empty explains itself and offers a way back', (
     tester,
@@ -134,31 +136,64 @@ void main() {
     expect(tapped?.id, 'one');
   });
 
-  testWidgets('sort chip tap invokes onSort with the tapped column', (
-    tester,
-  ) async {
-    ChannelSortColumn? sorted;
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            width: 800,
-            height: 600,
-            child: ChannelLibraryGrid(
-              channels: channels,
-              metadataByChannelId: const {},
-              onSort: (column) => sorted = column,
+  testWidgets(
+    'tapping the sort trigger then a column in the sheet invokes onSort',
+    (tester) async {
+      ChannelSortColumn? sorted;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 600,
+              child: ChannelLibraryGrid(
+                channels: channels,
+                metadataByChannelId: const {},
+                onSort: (column) => sorted = column,
+              ),
             ),
           ),
         ),
-      ),
-    );
+      );
 
-    await tester.tap(find.text('Category'));
-    await tester.pump();
+      await tester.tap(find.text('Sort: Name'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('channel-sort-category')));
+      await tester.pumpAndSettle();
 
-    expect(sorted, ChannelSortColumn.category);
-  });
+      expect(sorted, ChannelSortColumn.category);
+      // The sheet closes after picking a column.
+      expect(find.byKey(const ValueKey('channel-sort-category')), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'the sort sheet lists every ChannelSortColumn, including Type — the '
+    'old fixed four-chip row never exposed it at all',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 600,
+              child: ChannelLibraryGrid(
+                channels: channels,
+                metadataByChannelId: const {},
+                onSort: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Sort: Name'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('channel-sort-type')), findsOneWidget);
+      expect(find.text('Type'), findsOneWidget);
+    },
+  );
 
   testWidgets('TV action adds and removes channels from multiview', (
     tester,
@@ -187,6 +222,80 @@ void main() {
     await tester.pump();
 
     expect(toggled?.id, 'one');
+  });
+
+  testWidgets(
+    'long-pressing a tile opens an actions menu with Play, split view, and '
+    'favorite entries reflecting current state',
+    (tester) async {
+      IPTVChannel? played;
+      IPTVChannel? multiviewToggled;
+      IPTVChannel? favoriteToggled;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 600,
+              child: ChannelLibraryGrid(
+                channels: channels,
+                metadataByChannelId: const {},
+                onChannelSelected: (channel) => played = channel,
+                multiviewChannelIds: const {'one'},
+                onMultiviewToggle: (channel) => multiviewToggled = channel,
+                favoriteChannelIds: const {'two'},
+                onFavoriteToggle: (channel) => favoriteToggled = channel,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.longPress(find.text('One'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Play'), findsOneWidget);
+      // 'one' is already in multiview and is not a favorite.
+      expect(find.text('Remove from split view'), findsOneWidget);
+      expect(find.text('Add to favorites'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('channel-actions-favorite')));
+      await tester.pumpAndSettle();
+
+      expect(favoriteToggled?.id, 'one');
+      expect(played, isNull);
+      expect(multiviewToggled, isNull);
+      // The sheet closes after acting on an entry.
+      expect(find.text('Play'), findsNothing);
+    },
+  );
+
+  testWidgets('long-press actions menu omits entries with no callback wired', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 600,
+            child: ChannelLibraryGrid(
+              channels: channels,
+              metadataByChannelId: {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // No onChannelSelected/onMultiviewToggle/onFavoriteToggle wired at all
+    // means there is nothing to show — long-press is a no-op, not a sheet
+    // full of dead entries.
+    await tester.longPress(find.text('One'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Play'), findsNothing);
+    expect(find.byType(BottomSheet), findsNothing);
   });
 
   testWidgets('one D-pad press moves exactly one channel tile', (tester) async {

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/shell_settings_dialog_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/shell_settings_dialog_test.dart
@@ -24,16 +24,20 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const ValueKey('airo-tv-row-toggle-stats')));
+    // 'filter' rather than 'stats': stats now defaults hidden
+    // (#compact-tv-chrome), which is exactly what a separate test already
+    // covers — this test only needs a row that starts visible, to check
+    // that toggling it off works and persists.
+    await tester.tap(find.byKey(const ValueKey('airo-tv-row-toggle-filter')));
     await tester.pump();
 
     expect(
       container
           .read(controlRowVisibilityProvider)
-          .isVisible(AiroTvControlRow.stats),
+          .isVisible(AiroTvControlRow.filter),
       isFalse,
     );
-    expect(preferences.getBool('iptv_row_stats_visible'), isFalse);
+    expect(preferences.getBool('iptv_row_filter_visible'), isFalse);
     expect(
       find.byKey(const ValueKey('airo-tv-shell-settings-done')),
       findsOneWidget,

--- a/packages/platform_media/lib/src/video_player_streaming_service.dart
+++ b/packages/platform_media/lib/src/video_player_streaming_service.dart
@@ -37,6 +37,17 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
   DateTime? _loadStartTime;
   bool _isBackgroundAudioMode = false;
 
+  /// True for an instance that shares the device with another
+  /// already-playing instance (MultiView's non-featured tiles) — an
+  /// app-level mute already keeps only one tile audible (see
+  /// [setVolume]/[toggleMute]), so this instance must not also compete for
+  /// exclusive Android/iOS audio focus. Without it, the platform's own
+  /// focus-loss handling silently pauses whichever instance loses that
+  /// fight — freezing its video, not just its audio — and nothing in this
+  /// class's own state ever reflects that external pause, so raising this
+  /// instance's volume afterward does not un-freeze it.
+  final bool _mixWithOthers;
+
   // Live edge detection (P0-1 through P0-4)
   final LiveEdgeDetector _liveEdgeDetector;
 
@@ -61,7 +72,12 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     LiveEdgeConfig? liveEdgeConfig,
     this._failoverBackoffBase = const Duration(milliseconds: 250),
     this.mediaSessionDelegate,
-  }) : _engine = engine ?? VideoPlayerAiroPlaybackEngine(),
+    bool mixWithOthers = false,
+  }) : // Public constructor label kept independent of the private field so
+       // callers outside this library can pass it by name.
+       // ignore: prefer_initializing_formals
+       _mixWithOthers = mixWithOthers,
+       _engine = engine ?? VideoPlayerAiroPlaybackEngine(),
        _audioContext = audioContext ?? AudioContextManager(),
        _liveEdgeDetector = LiveEdgeDetector(config: liveEdgeConfig) {
     _setupLiveEdgeCallbacks();
@@ -86,7 +102,10 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     try {
       await call(delegate);
     } catch (e) {
-      PlatformMediaLogger.info('Media session delegate error: $e', tag: 'MEDIA_SESSION');
+      PlatformMediaLogger.info(
+        'Media session delegate error: $e',
+        tag: 'MEDIA_SESSION',
+      );
     }
   }
 
@@ -222,7 +241,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
                 // reliable pre-open live/VOD signal on IPTVChannel.
                 mediaKind: AiroPlaybackMediaKind.hls,
                 externalSubtitles: externalSubtitles,
-                mixWithOthers: _isBackgroundAudioMode,
+                mixWithOthers: _mixWithOthers || _isBackgroundAudioMode,
                 allowBackgroundPlayback:
                     _isBackgroundAudioMode || channel.isAudioOnly,
                 httpHeaders: source.httpHeaders,
@@ -657,12 +676,11 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
   void _beginMetricsSession(String channelId, String sourceId) {
     _finalizeMetricsSession();
     _metricsActiveSourceId = sourceId;
-    _metricsCollector =
-        StreamingSessionMetricsCollector(
-          sessionId: '$channelId-${DateTime.now().microsecondsSinceEpoch}',
-          activeSourceId: sourceId,
-          networkKey: _placeholderNetworkKey,
-        )..sessionStarted();
+    _metricsCollector = StreamingSessionMetricsCollector(
+      sessionId: '$channelId-${DateTime.now().microsecondsSinceEpoch}',
+      activeSourceId: sourceId,
+      networkKey: _placeholderNetworkKey,
+    )..sessionStarted();
     PlatformMediaLogger.analytics(
       'streaming_session_started',
       params: {'network_key': _placeholderNetworkKey},

--- a/packages/platform_media/test/video_player_streaming_service_test.dart
+++ b/packages/platform_media/test/video_player_streaming_service_test.dart
@@ -204,6 +204,30 @@ void main() {
         expect(openedRequest.allowBackgroundPlayback, isTrue);
       },
     );
+
+    test(
+      'a service constructed with mixWithOthers:true opens with mixWithOthers '
+      'set without requesting allowBackgroundPlayback (MultiView tiles: an '
+      'app-level mute already keeps only one tile audible, so this instance '
+      'must not also compete for exclusive platform audio focus — losing '
+      'that fight silently freezes its video, not just its audio, per '
+      'VideoPlayerStreamingService\'s `_mixWithOthers` doc comment)',
+      () async {
+        final concurrentEngine = VideoPlayerAiroPlaybackEngine();
+        final concurrentService = VideoPlayerStreamingService(
+          engine: concurrentEngine,
+          mixWithOthers: true,
+        );
+        addTearDown(concurrentService.dispose);
+
+        await concurrentService.playChannel(channel());
+
+        final openedRequest = concurrentEngine.currentState.request;
+        expect(openedRequest, isNotNull);
+        expect(openedRequest!.mixWithOthers, isTrue);
+        expect(openedRequest.allowBackgroundPlayback, isFalse);
+      },
+    );
   });
 
   group('VideoPlayerStreamingService multi-source failover', () {


### PR DESCRIPTION
## Summary

Three things found/asked for while manually testing MultiView on a physical Pixel 9 (Aika Stream):

### 1. Fix: non-featured MultiView tile freezes (commit 1)
Each MultiView session opens its own `VideoPlayerStreamingService` and mutes itself via `setVolume(0)` — but without `VideoPlayerOptions.mixWithOthers`, the underlying `video_player` engine still competes for exclusive platform audio focus. Whichever instance loses that fight gets silently paused by the platform (freezing its **video**, not just its audio), and nothing in the app's own state reflects that external pause — so promoting it back to "featured" afterward doesn't recover it.

Added a `mixWithOthers` constructor flag to `VideoPlayerStreamingService`, wired `true` for MultiView's session factory. **Verified fixed on physical Pixel 9**: two channels in split view now both keep advancing frames continuously regardless of which is muted (screenshots taken seconds apart show both tiles progressing).

### 2. Long-press channel actions menu (commit 2)
Long-pressing a channel tile now opens an actions sheet (Play / add-remove split view / add-remove favorite) instead of silently toggling MultiView. The always-on "+" overlay icon stays for fast one-tap access; the long-press is now a discoverable alternative that also covers favoriting, which the grid had no way to do before at all.

### 3. Compact TV browse chrome (commit 2)
- The Stats row (codec/resolution/bitrate) now **defaults hidden** — diagnostic detail, not something most viewers need permanently taking a row. Settings still turns it back on and that choice persists exactly as before.
- The four always-visible sort chips (Name/Category/Language/Country) collapse into one **"Sort: <column>" trigger** that opens a picker sheet — same columns, plus it now also surfaces `ChannelSortColumn.type` (audio-only vs live), which the old fixed 4-chip row never exposed at all.

## Test plan
- [x] `flutter analyze` clean on all touched files (`platform_media`, `feature_iptv`)
- [x] New unit test: `VideoPlayerStreamingService` constructed with `mixWithOthers: true` opens with that flag set, without forcing `allowBackgroundPlayback`
- [x] New widget tests: long-press actions sheet reflects current split-view/favorite state and acts correctly; sheet omits itself when nothing is wired; compact sort trigger opens a sheet listing all sort columns including Type
- [x] Updated existing tests whose assertions depended on the old always-visible 4-chip sort row / stats-visible-by-default (control_row_visibility, shell_settings_dialog, airo_tv_shell, channel_library_grid, iptv_screen)
- [x] Full `feature_iptv` + `platform_media` suites: 884+37 passing, only 2 pre-existing failures verified identical on unmodified `origin/main` (unrelated: a leak-tracker teardown flake and a VOD-resume pump-timer issue)
- [x] Freeze fix and compact layout **visually verified on physical Pixel 9** (Aika Stream debug build)
- [ ] Long-press gesture itself not device-verified — `adb shell input swipe` (used to simulate long-press) did not reliably trigger it on this rig; widget tests cover the logic directly via Flutter's real `tester.longPress()`, but a real-finger check on device would still be good before shipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)