### PR TITLE
fix(tv): scope editorial redesign to touch/cursor flavor, not D-pad

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -177,7 +177,13 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
       onFavoriteToggle: (channel) => favoriteToggler(channel.id),
       onClearFilters: () => ref.read(channelFiltersProvider.notifier).clear(),
     );
-    final infoBar = ChannelInfoBar(
+    // Built per-branch (compact vs ten-foot) below, not once here: the
+    // phone-width touch/cursor layout gets the dense editorial treatment
+    // (`compact: true`), the ten-foot D-pad layout keeps its original,
+    // larger-text presentation — shrinking text to fit a second line would
+    // cut against 10ft legibility, and that flavor was never in scope of
+    // the editorial redesign feedback this parameter was added for.
+    ChannelInfoBar infoBarFor(bool compact) => ChannelInfoBar(
       channel: widget.currentChannel,
       // Same grid-first signal `onHelpTap` keys off: no video stage means
       // the ten-foot layout, where `share_plus` is stubbed and the share
@@ -192,14 +198,16 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
           ? null
           : () => _captureVideoFrame(context),
       autofocus: infoBarAutofocus,
+      compact: compact,
     );
     final hotbar = Hotbar(
       channels: widget.channels,
       onChannelSelected: widget.onChannelSelected,
     );
-    final filterRow = FilterRow(
+    FilterRow filterRowFor(bool compact) => FilterRow(
       dimensions: snapshot.dimensions,
       autofocus: filterRowAutofocus,
+      compact: compact,
     );
     final videoStage = _VideoStageWithActions(
       child: KeyedSubtree(
@@ -228,7 +236,11 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
         final chrome = [
           const _OfflineBanner(),
           if (showChannel)
-            _ExplorerSection(label: 'LIVE', height: 60, child: infoBar),
+            _ExplorerSection(
+              label: 'LIVE',
+              height: 60,
+              child: infoBarFor(false),
+            ),
           if (showStats)
             _ExplorerSection(
               label: 'STATS',
@@ -238,15 +250,19 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
           if (showHotbar)
             _ExplorerSection(label: 'HOTBAR', height: 56, child: hotbar),
           if (showFilter)
-            _ExplorerSection(label: 'FILTER', height: 48, child: filterRow),
+            _ExplorerSection(
+              label: 'FILTER',
+              height: 48,
+              child: filterRowFor(false),
+            ),
         ];
         final compactChrome = [
           const _OfflineBanner(),
-          if (showChannel) infoBar,
+          if (showChannel) infoBarFor(true),
           if (showStats)
             SizedBox(height: 48, child: PlaybackStatsBar(stats: playbackStats)),
           if (showHotbar) hotbar,
-          if (showFilter) filterRow,
+          if (showFilter) filterRowFor(true),
         ];
         if (constraints.maxWidth < 600) {
           return FocusTraversalGroup(

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
@@ -20,6 +20,7 @@ class ChannelInfoBar extends ConsumerWidget {
     this.onScreenshotTap,
     this.showShareAction = true,
     this.autofocus = false,
+    this.compact = false,
   });
 
   final IPTVChannel? channel;
@@ -54,9 +55,16 @@ class ChannelInfoBar extends ConsumerWidget {
   /// which optional icons are present.
   final bool autofocus;
 
+  /// Renders the dense two-line editorial header (name, then category ·
+  /// LIVE pill) used on the phone-width touch/cursor layout. False keeps
+  /// the original single-line, larger-text treatment this row has always
+  /// had on the ten-foot D-pad layout — shrinking that text to fit a
+  /// second line would cut against 10ft legibility at TV viewing distance,
+  /// and the D-pad flavor was never part of the editorial redesign request.
+  final bool compact;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
     final name = channel?.name ?? 'Choose a channel';
     final isFavorite = channel != null
         ? ref.watch(isChannelFavoriteProvider(channel!.id))
@@ -71,67 +79,20 @@ class ChannelInfoBar extends ConsumerWidget {
           ChannelLogo(
             logoUrl: channel?.effectiveLogoUrl,
             channelName: name,
-            size: 36,
+            size: compact ? 36 : 32,
             isAudioOnly: channel?.isAudioOnly ?? false,
           ),
           const SizedBox(width: 10),
           Expanded(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  name,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: theme.textTheme.titleSmall?.copyWith(
-                    fontSize: 15,
-                    height: 1.1,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                if (channel != null) ...[
-                  const SizedBox(height: 1),
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (category != null && category.isNotEmpty) ...[
-                        Flexible(
-                          child: Text(
-                            category,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              fontSize: 11,
-                              height: 1.1,
-                              color: theme.colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 6),
-                        Text(
-                          '·',
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            fontSize: 11,
-                            height: 1.1,
-                            color: theme.colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                        const SizedBox(width: 6),
-                      ],
-                      const AiroBadge(
-                        label: 'LIVE',
-                        variant: AiroBadgeVariant.live,
-                        size: AiroBadgeSize.sm,
-                        pulse: false,
-                      ),
-                    ],
-                  ),
-                ],
-              ],
-            ),
+            child: compact
+                ? _CompactHeader(
+                    name: name,
+                    category: category,
+                    showMeta: channel != null,
+                  )
+                : Text(name, overflow: TextOverflow.ellipsis),
           ),
+          if (!compact) const Chip(label: Text('LIVE')),
           if (onHelpTap != null)
             TvFocusable(
               autofocus: autofocus,
@@ -300,5 +261,79 @@ class ChannelInfoBar extends ConsumerWidget {
           const SnackBar(content: Text('Could not copy channel details.')),
         );
     }
+  }
+}
+
+/// Two-line editorial header (name, then category · LIVE pill) used only
+/// on the compact touch/cursor layout — see [ChannelInfoBar.compact].
+class _CompactHeader extends StatelessWidget {
+  const _CompactHeader({
+    required this.name,
+    required this.category,
+    required this.showMeta,
+  });
+
+  final String name;
+  final String? category;
+  final bool showMeta;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontSize: 15,
+            height: 1.1,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        if (showMeta) ...[
+          const SizedBox(height: 1),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (category != null && category!.isNotEmpty) ...[
+                Flexible(
+                  child: Text(
+                    category!,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontSize: 11,
+                      height: 1.1,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  '·',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontSize: 11,
+                    height: 1.1,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(width: 6),
+              ],
+              const AiroBadge(
+                label: 'LIVE',
+                variant: AiroBadgeVariant.live,
+                size: AiroBadgeSize.sm,
+                pulse: false,
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
   }
 }

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_row.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/filter_row.dart
@@ -12,6 +12,7 @@ class FilterRow extends ConsumerWidget {
     super.key,
     required this.dimensions,
     this.autofocus = false,
+    this.compact = false,
   });
 
   final ChannelFilterDimensions dimensions;
@@ -19,6 +20,14 @@ class FilterRow extends ConsumerWidget {
   /// Seeds D-pad focus on the first (Search) chip when this is the topmost
   /// visible ten-foot chrome row.
   final bool autofocus;
+
+  /// Lighter inactive-chip weight for the phone-width touch/cursor layout,
+  /// so the active filter reads as the only prominent one. False keeps the
+  /// original, higher-contrast chip background this row has always had on
+  /// the ten-foot D-pad layout — legibility at TV viewing distance matters
+  /// more there than the phone-only "too many equal-weight pills" feedback
+  /// this flag was added for.
+  final bool compact;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -54,6 +63,7 @@ class FilterRow extends ConsumerWidget {
             _showSearchOverlay(context, dimensions, notifier, filters.search),
         onClear: filters.search.isEmpty ? null : () => notifier.setSearch(''),
         autofocus: autofocus,
+        compact: compact,
       ),
       if (dimensions.categories.isNotEmpty)
         _FilterChip(
@@ -61,6 +71,7 @@ class FilterRow extends ConsumerWidget {
           label: filters.category ?? 'Category',
           active: filters.category != null,
           icon: Icons.category_outlined,
+          compact: compact,
           onSelected: () => showTvLongListPicker(
             context: context,
             title: 'Category',
@@ -80,6 +91,7 @@ class FilterRow extends ConsumerWidget {
           label: countryLabel(filters.country),
           active: filters.country != null,
           icon: Icons.flag,
+          compact: compact,
           onSelected: () => showTvLongListPicker(
             context: context,
             title: 'Country',
@@ -100,6 +112,7 @@ class FilterRow extends ConsumerWidget {
           label: languageLabel(filters.language),
           active: filters.language != null,
           icon: Icons.translate,
+          compact: compact,
           onSelected: () => showTvLongListPicker(
             context: context,
             title: 'Language',
@@ -158,6 +171,7 @@ class FilterRow extends ConsumerWidget {
         onSelected: chip.onSelected,
         onClear: chip.onClear,
         expanded: true,
+        compact: chip.compact,
       );
     }
     return chip;
@@ -191,6 +205,7 @@ class _FilterChip extends StatelessWidget {
     this.onClear,
     this.expanded = false,
     this.autofocus = false,
+    this.compact = false,
   });
 
   final String label;
@@ -200,6 +215,7 @@ class _FilterChip extends StatelessWidget {
   final VoidCallback? onClear;
   final bool expanded;
   final bool autofocus;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
@@ -207,7 +223,7 @@ class _FilterChip extends StatelessWidget {
     final scheme = theme.colorScheme;
     final background = active
         ? scheme.primaryContainer
-        : scheme.surfaceContainerHighest.withValues(alpha: 0.46);
+        : scheme.surfaceContainerHighest.withValues(alpha: compact ? 0.46 : 0.72);
     final foreground = active
         ? scheme.onPrimaryContainer
         : scheme.onSurfaceVariant;


### PR DESCRIPTION
## Summary
Gap analysis after #1969 merged, checking the redesign against both interaction flavors Aika Stream must support: touch/cursor (phone-width) and D-pad (ten-foot TV). Found two of the four changes leaked into the shared D-pad flavor unintentionally:

- **`ChannelInfoBar`**: the new two-line editorial header shrank name/category/LIVE text (16→15/12→11sp, LIVE badge md→sm) to fit inside the existing 60px row height. That row is shared by the ten-foot `AiroTvShell` chrome — shrinking legible-at-10ft text there was never asked for and cuts against the android-tv-design legibility rule.
- **`FilterRow`**: the lighter inactive-chip alpha (0.72 → 0.46), meant to de-emphasize unselected phone filters, applied to the same shared TV filter row, reducing contrast at TV viewing distance.

Both are now gated behind a `compact` flag threaded from `AiroTvShell`'s existing phone-vs-ten-foot `LayoutBuilder` branch (the same boundary `ChannelLibraryGrid`'s `horizontal` flag and the hero video frame already use):
- `compact: true` (phone/touch/cursor) → new editorial two-line header, lighter filter chips
- `compact: false` (ten-foot/D-pad) → original single-line header + `Chip('LIVE')`, original 0.72 chip alpha — i.e. pixel-identical to pre-#1969 D-pad behavior

No changes needed to the horizontal channel card or hero video frame — both were already correctly scoped to the compact-only branch in the original PR.

## Test plan
- [x] `flutter analyze` clean on all touched files
- [x] All 51 existing widget tests pass (`channel_library_grid_test.dart`, `channel_info_bar_test.dart`, `airo_tv_shell_test.dart`, `filter_row_test.dart`)
- [x] `iptv_screen_test.dart`: 33/34 pass; the one failure (`ten-foot mode suppresses touch-only player chrome`) reproduces identically on `main` without this change — pre-existing flake, unrelated

## Also flagged, not fixed here (separate concern)
`DeviceFormFactorDetector` treats every detected TV uniformly as D-pad-only (`supportsDpadNavigation` / `needs10ftUI` both key off the same binary `tv` form factor) — there's no signal today for a touch- or cursor-capable TV display (e.g. Google TV boxes with mouse/touch panels). `TvFocusable` does already handle mouse hover generically (`MouseRegion` + `SystemMouseCursors.click`), so cursor input on a TV isn't broken, but there's no dedicated cursor-optimized TV layout — everyone on TV hardware gets the same D-pad-oriented `AiroTvShell` wide path regardless of pointer capability. Worth a separate issue if a cursor-first TV flavor is actually wanted, rather than folding it into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)