### PR TITLE
fix(tv): LIVE badge radius token + regression coverage for #1969/#1970

### DIFF
--- a/packages/core_ui/lib/src/widgets/airo_badge.dart
+++ b/packages/core_ui/lib/src/widgets/airo_badge.dart
@@ -13,9 +13,10 @@ class AiroBadge extends StatefulWidget {
     this.variant = AiroBadgeVariant.neutral,
     this.size = AiroBadgeSize.md,
     this.pulse = false,
+    this.borderRadius,
   });
 
-  const AiroBadge.live({super.key, this.pulse = true})
+  const AiroBadge.live({super.key, this.pulse = true, this.borderRadius})
     : label = 'LIVE',
       variant = AiroBadgeVariant.live,
       size = AiroBadgeSize.md;
@@ -24,12 +25,20 @@ class AiroBadge extends StatefulWidget {
     : label = 'PRO',
       variant = AiroBadgeVariant.pro,
       size = AiroBadgeSize.sm,
-      pulse = false;
+      pulse = false,
+      borderRadius = null;
 
   final String label;
   final AiroBadgeVariant variant;
   final AiroBadgeSize size;
   final bool pulse;
+
+  /// Overrides the variant's default corner radius (4px for `live`, 9999px
+  /// — a full pill — for everything else). Null keeps that default; callers
+  /// that need a specific radius (e.g. matching a design system's small-badge
+  /// token) pass it explicitly rather than this widget guessing per call
+  /// site.
+  final double? borderRadius;
 
   @override
   State<AiroBadge> createState() => _AiroBadgeState();
@@ -65,7 +74,7 @@ class _AiroBadgeState extends State<AiroBadge>
         : const EdgeInsets.symmetric(horizontal: 8, vertical: 3);
     final fontSize = isSm ? 9.0 : 11.0;
     final isRound = widget.variant == AiroBadgeVariant.live;
-    final radius = isRound ? 4.0 : 9999.0;
+    final radius = widget.borderRadius ?? (isRound ? 4.0 : 9999.0);
 
     return Container(
       padding: padding,

--- a/packages/core_ui/test/widgets/airo_badge_test.dart
+++ b/packages/core_ui/test/widgets/airo_badge_test.dart
@@ -1,0 +1,54 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  BoxDecoration decorationOf(WidgetTester tester) {
+    final container = tester
+        .widgetList<Container>(
+          find.descendant(
+            of: find.byType(AiroBadge),
+            matching: find.byType(Container),
+          ),
+        )
+        .first;
+    return container.decoration! as BoxDecoration;
+  }
+
+  testWidgets('live badge defaults to its 4px radius', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: AiroBadge.live(pulse: false))),
+    );
+
+    final radius = decorationOf(tester).borderRadius! as BorderRadius;
+    expect(radius.topLeft.x, 4.0);
+  });
+
+  testWidgets('borderRadius overrides the variant default', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: AiroBadge.live(pulse: false, borderRadius: AiroSpacing.radiusSm),
+        ),
+      ),
+    );
+
+    final radius = decorationOf(tester).borderRadius! as BorderRadius;
+    expect(radius.topLeft.x, AiroSpacing.radiusSm);
+  });
+
+  testWidgets('non-live badges stay pill-shaped unless overridden', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: AiroBadge(label: 'PRO', variant: AiroBadgeVariant.pro),
+        ),
+      ),
+    );
+
+    final radius = decorationOf(tester).borderRadius! as BorderRadius;
+    expect(radius.topLeft.x, 9999.0);
+  });
+}

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_info_bar.dart
@@ -329,6 +329,7 @@ class _CompactHeader extends StatelessWidget {
                 variant: AiroBadgeVariant.live,
                 size: AiroBadgeSize.sm,
                 pulse: false,
+                borderRadius: AiroSpacing.radiusSm,
               ),
             ],
           ),

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/channel_library_grid.dart
@@ -691,7 +691,10 @@ class _HorizontalMediaCard extends StatelessWidget {
               ),
               if (isLive) ...[
                 const SizedBox(width: 8),
-                const AiroBadge.live(pulse: false),
+                const AiroBadge.live(
+                  pulse: false,
+                  borderRadius: AiroSpacing.radiusSm,
+                ),
               ],
             ],
           ),

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_info_bar_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/channel_info_bar_test.dart
@@ -1,3 +1,4 @@
+import 'package:core_ui/core_ui.dart';
 import 'package:feature_iptv/application/channel_share.dart';
 import 'package:feature_iptv/application/iptv_deep_link.dart';
 import 'package:feature_iptv/application/providers/channel_filters_provider.dart';
@@ -53,6 +54,62 @@ void main() {
 
       expect(preferences.getStringList('iptv_favorite_channel_ids'), isEmpty);
       expect(find.byTooltip('Favorite'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'compact defaults to false, keeping the original single-line ten-foot header',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final preferences = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(body: ChannelInfoBar(channel: channel)),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Original ten-foot presentation: a plain Chip carries the LIVE
+      // label, not the compact editorial AiroBadge pill.
+      expect(find.byType(Chip), findsOneWidget);
+      expect(find.widgetWithText(Chip, 'LIVE'), findsOneWidget);
+      expect(find.byType(AiroBadge), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'compact: true renders the two-line editorial header instead of the Chip',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final preferences = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(
+              body: ChannelInfoBar(channel: channel, compact: true),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Chip), findsNothing);
+      expect(find.byType(AiroBadge), findsOneWidget);
+      expect(find.text('Example Channel'), findsOneWidget);
     },
   );
 

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/filter_row_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/filter_row_test.dart
@@ -51,6 +51,83 @@ void main() {
     );
   });
 
+  testWidgets(
+    'compact defaults to false, keeping the original higher-contrast '
+    'inactive-chip background for the ten-foot D-pad layout',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(
+              body: FilterRow(
+                dimensions: ChannelFilterDimensions(
+                  categories: {'News'},
+                  countries: {},
+                  languages: {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final material = tester.widget<Material>(
+        find.descendant(
+          of: find.byKey(const ValueKey('filter-chip-category')),
+          matching: find.byType(Material),
+        ),
+      );
+      expect(material.color!.a, closeTo(0.72, 0.001));
+    },
+  );
+
+  testWidgets(
+    'compact: true lightens the inactive-chip background for the phone '
+    'touch/cursor layout',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(
+              body: FilterRow(
+                compact: true,
+                dimensions: ChannelFilterDimensions(
+                  categories: {'News'},
+                  countries: {},
+                  languages: {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final material = tester.widget<Material>(
+        find.descendant(
+          of: find.byKey(const ValueKey('filter-chip-category')),
+          matching: find.byType(Material),
+        ),
+      );
+      expect(material.color!.a, closeTo(0.46, 0.001));
+    },
+  );
+
   testWidgets('wide filter row keeps category and country labels readable', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
Third-pass gap analysis over the full redesign thread (#1969, #1970). Found two remaining loose ends, both fixed here:

1. **LIVE badge radius didn't match spec.** Both redesigned LIVE badges (`ChannelInfoBar`'s compact header, `ChannelLibraryGrid`'s horizontal card) reuse the shared `AiroBadge.live` component — which hardcodes a 4px radius, not the 8px "small badges" token the original design feedback specified. `AiroBadge` now accepts an optional `borderRadius` override; default behavior (and the pre-existing `iptv_mini_player.dart` caller) is unchanged, both redesigned call sites now pass `AiroSpacing.radiusSm` explicitly.
2. **No dedicated tests for what #1969/#1970 actually changed.** The D-pad leak fixed in #1970 was only caught indirectly, via an unrelated overflow assertion — nothing directly asserted the `compact` branch behavior. Added:
   - `AiroBadge` radius-override tests (default vs override vs non-live pill)
   - `ChannelInfoBar`: compact defaults to `false` → original `Chip('LIVE')`; `compact: true` → editorial header, no `Chip`
   - `FilterRow`: compact defaults to `false` → 0.72 inactive-chip alpha; `compact: true` → 0.46

## Test plan
- [x] `flutter analyze` clean across `core_ui` and `feature_iptv`
- [x] New tests pass: 3/3 (`airo_badge_test.dart`), 2/2 new `channel_info_bar_test.dart` cases, 2/2 new `filter_row_test.dart` cases
- [x] Full `core_ui` suite: 107/107 pass
- [x] Full `feature_iptv` `tv_ux` + `iptv_screen_test.dart`: 130/131 pass — the one failure (`ten-foot mode suppresses touch-only player chrome`) reproduces identically on unmodified `main`, pre-existing flake unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)