### PR TITLE
fix(tv): update quality-gate test fixture for ic_notification keep rule

### DIFF
--- a/scripts/test-check-android-tv-native-media.sh
+++ b/scripts/test-check-android-tv-native-media.sh
@@ -59,7 +59,7 @@ good_resource_keep="$TMP_DIR/good-resource-keep.xml"
 cat >"$good_resource_keep" <<'EOF'
 <resources
     xmlns:tools="http://schemas.android.com/tools"
-    tools:keep="@drawable/audio_service_*" />
+    tools:keep="@drawable/audio_service_*,@mipmap/ic_notification" />
 EOF
 
 bad_resource_keep="$TMP_DIR/bad-resource-keep.xml"


### PR DESCRIPTION
## Summary
- `scripts/check-android-tv-release.sh` started requiring `@mipmap/ic_notification` in `keep.xml` in 5f4043d2 (notification-crash fix), but the release quality gate's own test fixture (`good_resource_keep` in `scripts/test-check-android-tv-native-media.sh`) was never updated — the `accepts-video-player-only-contract` happy-path case has been failing on `main` since that commit.
- Caught while dispatching the Aika Stream `0.0.1+16` release build (run [34161553932](https://github.com/DevelopersCoffee/airo/actions/runs/34161553932)), which is the first time this gate ran since the notification fix landed.
- Production `keep.xml` was already correct; only the test fixture was stale.

## Test plan
- [x] `bash scripts/test-check-android-tv-native-media.sh` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)