### PR TITLE
fix(tv): fake stream probe transport in iptv_screen_test.dart

### DIFF
--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -12,6 +12,20 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// Auto Scan's real transport makes actual HTTP requests, which flutter
+/// test's binding rejects with a blanket 400 -- silently marking every
+/// fake channel here "unavailable" and blocking tap-to-play (see
+/// airo_tv_shell_test.dart, which fakes this the same way).
+class _FakeProbeTransport implements StreamProbeTransport {
+  @override
+  Future<StreamProbeHttpResponse> get(
+    StreamProbeRequest request, {
+    required StreamProbeCancellation cancellation,
+  }) async {
+    return const StreamProbeHttpResponse(statusCode: 206);
+  }
+}
+
 void main() {
   final channels = [
     const IPTVChannel(
@@ -60,6 +74,9 @@ void main() {
         return ProviderScope(
           overrides: [
             sharedPreferencesProvider.overrideWithValue(snapshot.data!),
+            streamProbeTransportProvider.overrideWithValue(
+              _FakeProbeTransport(),
+            ),
             iptvChannelsProvider.overrideWith(
               (ref) async => channelLoader?.call() ?? channels,
             ),


### PR DESCRIPTION
## Summary
- Auto Scan's real transport makes actual HTTP requests. In `flutter test`, those get a blanket 400 from the test binding, which the auto-scan warmup (wired via `ChannelLibraryGrid.onVisibleChannelsChanged`) reads as every visible channel being unreachable — marking all three fake channels `StreamAvailability.unavailable` within the same `pumpAndSettle()` that's supposed to select one.
- `AiroTvShell._selectChannel` correctly refuses to play a confirmed-unavailable channel, so `ten-foot mode suppresses touch-only player chrome` taps a channel and never gets a mounted `VideoPlayerWidget`.
- Caught while dispatching the Aika Stream `0.0.1+16` release build (run [34162653120](https://github.com/DevelopersCoffee/airo/actions/runs/34162653120)) — nobody had run `feature_iptv`'s full test suite since whatever PR added the auto-scan warmup landed on `main`.
- Fix follows the existing pattern in `airo_tv_shell_test.dart`, which already fakes `streamProbeTransportProvider` for the same reason.

## Test plan
- [x] `flutter test test/iptv/presentation/screens/iptv_screen_test.dart test/iptv/iptv_cast_ui_test.dart test/iptv/iptv_cast_notifier_test.dart` — 51/51 pass
- [x] `flutter analyze test/iptv/presentation/screens/iptv_screen_test.dart` — clean
- [x] Full release quality-gate script suite (`check-android-tv-release.sh`, `test-check-android-tv-native-media.sh`, tv_router/main_tv/platform_media/platform_player targets) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)