### PR TITLE
fix(tv): stop Cast Connect receiver crashing every launch on Android 13+

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -56,6 +56,19 @@ val variantAppLabel = when (appVariant) {
     else -> "Airo"
 }
 
+// Cast Connect's receiver-side init (AiroCastReceiverApplication,
+// AiroCastReceiverMultiviewPlugin) is dev/test only -- the F353F9C7 receiver
+// app is unpublished and unreachable by any real user's Cast device. Gated
+// on the same dart-define the sender side already requires
+// (flutter_chrome_cast_controller.dart's defaultReceiverApplicationId) so one
+// flag turns on both halves; a normal release build never passes it, so
+// CastReceiverContext is never touched. Without this gate, initializing it
+// unconditionally crashes every launch on Android 13+ (targetSdk 34+): the
+// play-services-cast-tv 20.0.0 SDK's own CastReceiverContext.start() calls
+// registerReceiver() without RECEIVER_EXPORTED/RECEIVER_NOT_EXPORTED, which
+// that OS version enforces as a fatal SecurityException.
+val enableCastReceiver = isTvVariant && !dartDefine("CAST_MULTIVIEW_RECEIVER_APP_ID").isNullOrBlank()
+
 plugins {
     id("com.android.application")
     // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
@@ -119,6 +132,10 @@ android {
         checkReleaseBuilds = false
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     defaultConfig {
         applicationId = variantApplicationId
         minSdk = libs.versions.airo.min.sdk.get().toInt()
@@ -126,6 +143,7 @@ android {
         versionCode = flutter.versionCode
         versionName = flutter.versionName
         manifestPlaceholders["appLabel"] = variantAppLabel
+        buildConfigField("boolean", "ENABLE_CAST_RECEIVER", "$enableCastReceiver")
 
         // Enable multidex for larger apps
         multiDexEnabled = true

--- a/app/android/app/src/tv/kotlin/io/airo/app/AiroCastReceiverApplication.kt
+++ b/app/android/app/src/tv/kotlin/io/airo/app/AiroCastReceiverApplication.kt
@@ -12,10 +12,15 @@ import com.google.android.gms.cast.tv.CastReceiverContext
  * Google's official sample (CastDemoApplication.kt / AppLifecycleObserver.kt
  * at github.com/googlecast/CastAndroidTvReceiver). Dev/test only: see
  * AiroCastReceiverOptionsProvider's doc comment.
+ *
+ * Gated on [BuildConfig.ENABLE_CAST_RECEIVER] (see build.gradle.kts):
+ * initInstance/start crash every launch on Android 13+ when the receiver
+ * app is never actually reachable, which is true for every real user.
  */
 class AiroCastReceiverApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        if (!BuildConfig.ENABLE_CAST_RECEIVER) return
         CastReceiverContext.initInstance(this)
         ProcessLifecycleOwner.get().lifecycle.addObserver(CastReceiverLifecycleObserver())
     }

--- a/app/android/app/src/tv/kotlin/io/airo/app/AiroCastReceiverMultiviewPlugin.kt
+++ b/app/android/app/src/tv/kotlin/io/airo/app/AiroCastReceiverMultiviewPlugin.kt
@@ -36,6 +36,12 @@ class AiroCastReceiverMultiviewPlugin {
         channel.setMethodCallHandler { call, result -> onMethodCall(call, result) }
         this.channel = channel
 
+        // AiroCastReceiverApplication only calls CastReceiverContext.initInstance
+        // when BuildConfig.ENABLE_CAST_RECEIVER is set -- getInstance() throws
+        // IllegalStateException otherwise, so this must stay in lockstep with
+        // that same gate (see AiroCastReceiverApplication's doc comment).
+        if (!BuildConfig.ENABLE_CAST_RECEIVER) return
+
         val receiverContext = CastReceiverContext.getInstance()
         receiverContext.setMessageReceivedListener(NAMESPACE) { _, senderId, message ->
             currentSenderId = senderId


### PR DESCRIPTION
## Summary
- **Release blocker for 0.0.1+16**: `AiroCastReceiverApplication` (wired as the `tv` flavor's `Application` class in #1974) unconditionally called `CastReceiverContext.initInstance()`/`.start()` at process start.
- `play-services-cast-tv:20.0.0`'s own `CastReceiverContext.start()` implementation calls `registerReceiver()` without `RECEIVER_EXPORTED`/`RECEIVER_NOT_EXPORTED`. Android 13+ (targetSdk 34+ — we're on 36) enforces that as a **fatal `SecurityException`**, not a warning. Every `tv`-flavor build crashed on first launch on any Android 13+ device.
- Confirmed on a physical Pixel 9 while smoke-testing Aika Stream `0.0.1+16` — the first release meant to reach phones/tablets (`leanback required=false`) instead of TV-only, i.e. exactly the audience this crash hits.
- The receiver app (`F353F9C7`) is unpublished and reachable only from a Cast device explicitly allowlisted in Google's console — no real user could ever connect to it, so this init served no purpose for anyone experiencing the crash.

## Fix
Gate the receiver-side init on the same dart-define the sender side already requires (`flutter_chrome_cast_controller.dart`'s `defaultReceiverApplicationId`, `CAST_MULTIVIEW_RECEIVER_APP_ID`) via a new `BuildConfig.ENABLE_CAST_RECEIVER` field:
- `AiroCastReceiverApplication.onCreate()` — skips `initInstance`/lifecycle observer registration when unset.
- `AiroCastReceiverMultiviewPlugin.register()` — skips `CastReceiverContext.getInstance()` (which throws `IllegalStateException` if `initInstance` was never called) when unset.
- A normal release build never passes the dart-define, so `CastReceiverContext` is never touched. Passing `--dart-define=CAST_MULTIVIEW_RECEIVER_APP_ID=F353F9C7` turns on both the sender targeting and the receiver init together, for whoever runs the Cast MultiView test plan.

## Test plan
- [x] `scripts/check-android-tv-release.sh` — passes
- [x] Local `scripts/build-tv.sh --apk-only` (no dart-define, matching release CI) installed on a Pixel 9 that previously crashed on every launch of the `0.0.1+16` release build — now launches cleanly to the empty-state screen
- [ ] Re-run `aika-stream-release.yml` for `0.0.1+16` after merge and re-verify on the same Pixel 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)