### PR TITLE
fix(tv): MissingPluginException on TV cold start + bug-report dropdown overflow

### DIFF
--- a/.claude/skills/run-airo-tv/SKILL.md
+++ b/.claude/skills/run-airo-tv/SKILL.md
@@ -29,16 +29,35 @@ flutter run -d macos -t lib/main_tv.dart
 
 Swap `-d macos` for `-d chrome`, `-d <android-device-id>`, etc. as needed.
 
-### Android target: `flutter run` always shows the wrong version, `flutter build` must not
+### Android target: swap in `pubspec_tv.yaml` first — `flutter run` needs it too
 
 `--target=lib/main_tv.dart` only picks the Dart entrypoint — it does **not** make Flutter
-read `app/pubspec_tv.yaml`. Android's real `versionName`/`versionCode` always come from
-whichever pubspec Flutter defaults to (`app/pubspec.yaml`, the phone app's own version).
+read `app/pubspec_tv.yaml`. Skip the swap and you get more than a cosmetic version number:
+`pubspec_tv.yaml` replaces several plugins with no-op stubs (`media_kit_libs_android_video`
+among them) so their Android side never registers. Without the swap, the *real*
+`media_kit_libs_android_video` plugin loads, and its native `System.loadLibrary("mpv")`
+throws `UnsatisfiedLinkError` on every launch — the TV Gradle config always strips
+`libmpv.so` from the APK regardless of which pubspec built it. Every later channel call that
+plugin should have served then throws `MissingPluginException`, which the global error
+handler surfaces as an auto-popping bug report dialog on nearly every cold start.
 
-`flutter run` has no `--build-name`/`--build-number` flags at all, so a debug `flutter run
--d <device> -t lib/main_tv.dart ...` session will always install with the phone app's
-version baked in (e.g. Settings shows "0.0.7 (12)" instead of Aika Stream's real version) —
-harmless for a throwaway debug session, but don't read anything into that number.
+Always run this from `app/` before `flutter run` **or** `flutter build` against
+`main_tv.dart`:
+
+```bash
+cp pubspec_tv.yaml pubspec.yaml && flutter pub get
+```
+
+(`scripts/build-tv.sh` does this automatically for release builds; a plain `flutter run`
+debug session does not, so do it by hand first.) Restore `app/pubspec.yaml` via `git
+checkout -- pubspec.yaml pubspec.lock` afterward if you also work on the phone app in the
+same checkout.
+
+Separately, Android's real `versionName`/`versionCode` always come from whichever pubspec
+built the APK — `flutter run` has no `--build-name`/`--build-number` flags at all, so even
+with the swap applied a debug session shows the version baked into `pubspec_tv.yaml` at
+build time, not necessarily what you'd expect from a mid-session edit. Harmless to ignore
+for a throwaway debug session.
 
 For anything you actually keep installed or hand to someone (`flutter build apk --release`,
 a local dogfood/sideload build), that same default is a real bug, not a display quirk — it

--- a/app/lib/core/error/global_error_handler.dart
+++ b/app/lib/core/error/global_error_handler.dart
@@ -90,7 +90,17 @@ class GlobalErrorHandler {
       stackTrace: stack,
     );
 
-    // Show bug report dialog for critical errors
+    // In debug mode, print to console instead of interrupting every dev
+    // session with the bug report dialog (matches _handleFlutterError's
+    // kDebugMode gate below).
+    if (kDebugMode) {
+      debugPrint(
+        '=== FULL ERROR DUMP ===\n$error\n$stack\n=== END FULL ERROR DUMP ===',
+      );
+      return true;
+    }
+
+    // In release mode, show bug report dialog for critical errors
     _showBugReportDialogIfNeeded(
       error: error,
       stackTrace: stack,

--- a/app/lib/main_tv.dart
+++ b/app/lib/main_tv.dart
@@ -3,6 +3,21 @@
 /// This entrypoint initializes a minimal app with only IPTV functionality.
 /// Target APK size: <120MB
 ///
+/// `--target=lib/main_tv.dart` alone only selects the Dart entrypoint --
+/// Android still resolves plugins from whichever `pubspec.yaml` is on disk,
+/// which defaults to the full phone app's. `pubspec_tv.yaml` swaps several
+/// plugins (media_kit_libs_android_video included) for no-op stubs so their
+/// Android side never registers; skip that swap and the *real*
+/// media_kit_libs_android_video plugin loads instead, whose native
+/// `System.loadLibrary("mpv")` throws `UnsatisfiedLinkError` on every launch
+/// -- TV's `build.gradle.kts` always strips `libmpv.so` from the APK -- and
+/// every later channel call that plugin should have served throws
+/// `MissingPluginException` instead. Always copy `pubspec_tv.yaml` over
+/// `pubspec.yaml` first, `flutter run` included, not just release builds:
+/// ```bash
+/// cp pubspec_tv.yaml pubspec.yaml && flutter pub get
+/// ```
+///
 /// Build command:
 /// ```bash
 /// flutter build apk --release \

--- a/app/lib/shared/widgets/bug_report_dialog.dart
+++ b/app/lib/shared/widgets/bug_report_dialog.dart
@@ -251,6 +251,7 @@ class _BugReportDialogState extends State<BugReportDialog> {
   Widget _buildSeverityDropdown() {
     return DropdownButtonFormField<BugSeverity>(
       initialValue: _severity,
+      isExpanded: true,
       decoration: const InputDecoration(
         labelText: 'Severity',
         border: OutlineInputBorder(),
@@ -259,7 +260,10 @@ class _BugReportDialogState extends State<BugReportDialog> {
       items: BugSeverity.values.map((severity) {
         return DropdownMenuItem(
           value: severity,
-          child: Text('${severity.label} - ${severity.description}'),
+          child: Text(
+            '${severity.label} - ${severity.description}',
+            overflow: TextOverflow.ellipsis,
+          ),
         );
       }).toList(),
       onChanged: (value) {
@@ -271,6 +275,7 @@ class _BugReportDialogState extends State<BugReportDialog> {
   Widget _buildCategoryDropdown() {
     return DropdownButtonFormField<BugCategory>(
       initialValue: _category,
+      isExpanded: true,
       decoration: const InputDecoration(
         labelText: 'Category',
         border: OutlineInputBorder(),
@@ -279,7 +284,10 @@ class _BugReportDialogState extends State<BugReportDialog> {
       items: BugCategory.values.map((category) {
         return DropdownMenuItem(
           value: category,
-          child: Text('${category.label} - ${category.description}'),
+          child: Text(
+            '${category.label} - ${category.description}',
+            overflow: TextOverflow.ellipsis,
+          ),
         );
       }).toList(),
       onChanged: (value) {

--- a/app/test/shared/widgets/bug_report_dialog_test.dart
+++ b/app/test/shared/widgets/bug_report_dialog_test.dart
@@ -19,4 +19,42 @@ void main() {
       expect(find.textContaining('token'), findsNothing);
     },
   );
+
+  testWidgets(
+    'severity and category dropdowns do not overflow on a phone-width screen',
+    (tester) async {
+      // 360dp width matches the ~360dp phone screen where the Severity and
+      // Category dropdowns previously overflowed their Row (creator chain
+      // Row <- ... <- InputDecorator, per the original report) because the
+      // selected-value Text had no Expanded/ellipsis for long labels like
+      // "High - Major issue affecting core functionality". This width also
+      // trips an unrelated, pre-existing overflow in the dialog's title Row
+      // (a flutter_test font-metrics artifact -- it never reproduces on a
+      // real device and isn't part of this regression), so the assertion
+      // below checks the exception text for the dropdowns specifically
+      // rather than asserting no exception at all. `tester.takeException()`
+      // is used rather than a custom `FlutterError.onError` override, which
+      // breaks flutter_test's own error-zone handling and hangs the test
+      // for its full timeout when more than one error occurs.
+      tester.view.physicalSize = const Size(360, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: BugReportDialog())),
+      );
+
+      // When more than one FlutterError occurs in a single pump,
+      // takeException() collapses them into a generic "Multiple exceptions"
+      // summary instead of the individual messages, so that case must be
+      // checked for directly rather than relying on message content alone.
+      final exception = tester.takeException()?.toString() ?? '';
+      expect(
+        exception,
+        allOf(isNot(contains('InputDecorator')), isNot(contains('Multiple'))),
+        reason: 'Severity/Category dropdown overflowed: $exception',
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- Root-caused the `MissingPluginException` auto-popping the bug-report dialog on nearly every Aika Stream TV cold start: `flutter run -t lib/main_tv.dart` doesn't read `pubspec_tv.yaml`, so the real `media_kit_libs_android_video` plugin registers instead of its TV no-op stub. TV's Gradle config always strips `libmpv.so` from the APK, so that plugin's native `<clinit>` throws `UnsatisfiedLinkError` on every engine creation, and any later media_kit channel call throws `MissingPluginException` instead. Documented the required `pubspec_tv.yaml` swap in `main_tv.dart` and the `run-airo-tv` skill.
- Fixed an independent bug in `GlobalErrorHandler`: `_handlePlatformError` was missing the `kDebugMode` gate its sibling `_handleFlutterError` already has, so it popped the bug-report dialog on every debug session instead of dumping to console.
- Fixed the bug-report dialog's Severity/Category dropdowns overflowing their `Row` on phone-width screens (`isExpanded` + ellipsis for long labels), with a regression test verified to fail on the prior code.

## Test plan
- [x] `flutter analyze` clean on all touched files
- [x] `flutter test test/shared/widgets/bug_report_dialog_test.dart` — new regression test passes with the fix, verified to fail against the pre-fix dropdown code
- [x] Reproduced the `MissingPluginException`/`UnsatisfiedLinkError` chain on a physical Pixel 9 with the un-swapped pubspec, confirmed clean across 4 cold starts after swapping in `pubspec_tv.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)