### PR TITLE
fix(tv): stop AiroTvShellState teardown on channel-list reload

### DIFF
--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -1582,6 +1582,18 @@ class _StreamTabContent extends ConsumerWidget {
     final streamingState = ref.watch(streamingStateProvider);
 
     return channelsAsync.when(
+      // iptvChannelsProvider re-runs whenever any of its watched
+      // dependencies changes (auto-scan availability, favorites, personal
+      // channels, ...) -- Riverpod calls that a "reload", distinct from an
+      // explicit invalidate/refresh, and `when()` does NOT skip the loading
+      // branch for a reload by default. Without this flag, any such
+      // dependency change -- triggerable by almost any interaction on this
+      // screen -- replaced this whole subtree with TvLoadingScreen and back,
+      // tearing down and recreating AiroTvShellState (and therefore
+      // invalidating any `ref` a caller had captured, e.g. mid-flight in
+      // _toggleMultiview) even though cached channel data was already on
+      // screen. See AsyncValue.when's skipLoadingOnReload/isReloading docs.
+      skipLoadingOnReload: true,
       data: (channels) => _buildContent(context, ref, channels, streamingState),
       loading: () => const TvLoadingScreen(message: 'Loading channels...'),
       error: (error, stack) => _buildError(context, ref, error.toString()),

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -443,27 +443,7 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
     BuildContext context,
     IPTVChannel channel,
   ) async {
-    // AiroTvShellState is observed to be transiently torn down and rebuilt
-    // by an ancestor within a second or so of almost any interaction here
-    // (root cause not yet isolated -- see the churn investigation notes).
-    // `ref` becomes briefly unusable during that window in a way
-    // `context.mounted` does not reliably catch (Riverpod's own disposal
-    // flag flips at Element.deactivate(), before Flutter's `mounted` does),
-    // so a synchronous ref.read can throw here even though this exact
-    // widget is back on screen a frame later. Retry once after a
-    // microtask beat rather than losing the toggle outright.
-    MultiviewToggleResult result;
-    try {
-      result = await ref.read(multiviewProvider.notifier).toggle(channel);
-    } on StateError {
-      await Future<void>.delayed(Duration.zero);
-      if (!context.mounted) return;
-      try {
-        result = await ref.read(multiviewProvider.notifier).toggle(channel);
-      } on StateError {
-        return;
-      }
-    }
+    final result = await ref.read(multiviewProvider.notifier).toggle(channel);
     if (!context.mounted) return;
     final message = switch (result) {
       MultiviewToggleResult.added => '${channel.name} added to multiview',

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_channel_reload_teardown_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_channel_reload_teardown_test.dart
@@ -1,0 +1,125 @@
+import "package:feature_iptv/application/channel_metadata_enrichment.dart";
+import "package:feature_iptv/feature_iptv.dart";
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Auto Scan's real transport makes actual HTTP requests, which flutter
+/// test's binding rejects -- see iptv_screen_test.dart / airo_tv_shell_test.dart.
+class _FakeProbeTransport implements StreamProbeTransport {
+  @override
+  Future<StreamProbeHttpResponse> get(
+    StreamProbeRequest request, {
+    required StreamProbeCancellation cancellation,
+  }) async => const StreamProbeHttpResponse(statusCode: 206);
+}
+
+void main() {
+  testWidgets(
+    'AiroTvShellState survives a channel-list reload triggered by one of '
+    "iptvChannelsProvider's own watched dependencies (not just an "
+    'invalidate/refresh)',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final reloadTrigger = StateProvider<int>((ref) => 0);
+      const channels = [
+        IPTVChannel(
+          id: 'news-1',
+          name: 'City News Live',
+          streamUrl: 'https://example.com/news.m3u8',
+          group: 'News',
+          category: ChannelCategory.news,
+        ),
+      ];
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          streamProbeTransportProvider.overrideWithValue(
+            _FakeProbeTransport(),
+          ),
+          channelBrowseMetadataProvider.overrideWith(
+            (ref) async => const <String, ChannelBrowseMetadata>{},
+          ),
+          recentlyWatchedChannelsProvider.overrideWith((ref) async => const []),
+          streamingStateProvider.overrideWith(
+            (ref) => Stream.value(
+              StreamingState(
+                playbackState: PlaybackState.idle,
+                isLiveStream: true,
+                liveDelay: const Duration(seconds: 1),
+              ),
+            ),
+          ),
+          // Stands in for any of iptvChannelsProvider's real dependencies
+          // (auto-scan availability, favorites, personal channels, the
+          // channel data service) recomputing. Using ref.watch -- not
+          // ref.invalidate -- is what makes this a "reload" rather than a
+          // "refresh" in Riverpod's AsyncValue vocabulary: only reload skips
+          // the loading branch by default.
+          iptvChannelsProvider.overrideWith((ref) async {
+            ref.watch(reloadTrigger);
+            return channels;
+          }),
+        ],
+      );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: IPTVScreen(tenFootMode: true)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AiroTvShell), findsOneWidget);
+      final shellStateBefore = tester.state(find.byType(AiroTvShell));
+
+      // Simulates the real-world trigger: some provider iptvChannelsProvider
+      // transitively watches changes value as a side effect of an ordinary
+      // interaction elsewhere on screen.
+      container.read(reloadTrigger.notifier).state++;
+      await tester.pump();
+
+      // A background reload of a provider that already has cached data must
+      // not blank the whole browse UI -- AiroTvShell should stay mounted,
+      // not get replaced by the full-screen loading state.
+      expect(
+        find.byType(AiroTvShell),
+        findsOneWidget,
+        reason:
+            'iptvChannelsProvider reloading (with cached data available) '
+            'must not swap AiroTvShell out for the full-screen loading state',
+      );
+
+      await tester.pumpAndSettle();
+
+      final shellStateAfter = tester.state(find.byType(AiroTvShell));
+      expect(
+        identical(shellStateBefore, shellStateAfter),
+        isTrue,
+        reason:
+            'AiroTvShellState must survive a dependency-driven channel-list '
+            'reload -- widgets holding a ref captured before the reload '
+            '(e.g. a pending _toggleMultiview call) must not find it torn '
+            'down underneath them',
+      );
+
+      // Drains AiroTvShell's own visible-channel-scan debounce timer (up to
+      // ~450ms, see channel_warmup_policy.dart) so its dispose() gets a
+      // chance to cancel it before teardown -- unrelated to the assertion
+      // above, just this screen's normal background behavior.
+      await tester.pump(const Duration(milliseconds: 500));
+      // Unmount and dispose the container explicitly, in that order and
+      // before the test body returns, so every State.dispose() and every
+      // provider's ref.onDispose() (and the Timers each cancels) run before
+      // the test binding's end-of-test "no pending timers" invariant check.
+      // addTearDown callbacks run too late for that check.
+      await tester.pumpWidget(const SizedBox());
+      container.dispose();
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- `_StreamTabContent`'s `channelsAsync.when()` used Riverpod's default `skipLoadingOnReload: false`, so any dependency-driven reload of `iptvChannelsProvider` (auto-scan availability, favorites, personal channels — triggerable by almost any interaction) swapped the whole `AiroTvShell` subtree for `TvLoadingScreen` and back, tearing down and recreating `_AiroTvShellState` (and its `ref`) even though cached channel data was already on screen.
- That's the confirmed root cause of the Pixel 9 / Aika Stream TV bug: `_toggleMultiview` throwing `StateError: Bad state: Using "ref" when a widget is about to or has been unmounted is unsafe.` on every attempt after the first interaction of a session, never recovering.
- Fix: set `skipLoadingOnReload: true` so a background reload keeps showing cached data instead of blanking to a loading screen, and drop the retry-with-backoff band-aid in `_toggleMultiview` now that `ref` no longer goes stale underneath it.

## Root cause, in detail
`iptvChannelsProvider` (`FutureProvider`) watches three dependencies (`_runtimeChannelsProvider`, `personalChannelsProvider`, `channelLibraryMergerProvider`). Any of them recomputing counts as a Riverpod "reload" (`AsyncValue.isReloading`), distinct from an explicit `invalidate()`/`refresh()` ("refresh"). `AsyncValue.when()` skips the `loading` branch on refresh by default, but **not** on reload — so every reload replayed `loading: () => const TvLoadingScreen(...)` at the exact same tree slot `AiroTvShell` normally occupies. Different widget type at that slot forces Flutter to unmount the whole subtree, disposing `_AiroTvShellState`, then remounts a fresh instance once the reload resolves.

## Verification
- Added a regression test (`iptv_screen_channel_reload_teardown_test.dart`) that forces `iptvChannelsProvider` to reload via a watched dependency and asserts `AiroTvShell`'s `State` survives — reproduced RED on the pre-fix code (`AiroTvShell` vanished from the tree after one `pump()`), GREEN after the fix.
- `airo_tv_shell_test.dart` (all) and `iptv_screen_test.dart` (all 54) pass.
- `flutter analyze` clean on touched files.
- Full `feature_iptv` `flutter test`: one pre-existing, unrelated failure (`iptv_screen_ten_foot_fullscreen_test.dart`, a `vodResumeCoordinatorProvider` crash) — confirmed present on baseline too by stashing this fix and rerunning.

## Test plan
- [x] New regression test passes
- [x] `airo_tv_shell_test.dart` full suite passes
- [x] `iptv_screen_test.dart` full suite passes
- [x] `flutter analyze` clean on touched files
- [ ] Manual on-device confirmation on Pixel 9 / Fire TV Stick that MultiView toggle no longer throws after repeated interactions (no physical device available in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)