### PR TITLE
style: fix pre-existing dart format drift in main_qualification.dart

### DIFF
--- a/app/lib/main_qualification.dart
+++ b/app/lib/main_qualification.dart
@@ -22,7 +22,6 @@ import 'features/iptv/iptv_cast_provider_override.dart';
 
 const _defaultPlaylistUrl = 'https://iptv-org.github.io/iptv/index.m3u';
 
-
 void main() {
   late SharedPreferences prefs;
   late ModuleRegistry registry;


### PR DESCRIPTION
## Summary
CI's \`dart format --set-exit-if-changed\` check has been failing on \`main\`'s tip since #1984 introduced this drift (unrelated to that PR's actual content, format-only). This was blocking \`analyze\`/\`code-quality\` checks on every subsequent PR, including #1986.

Pure formatting fix, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)