### PR TITLE
fix(tv): restore multiview error handling, reposition fullscreen button, fix overflow

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -443,7 +443,50 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
     BuildContext context,
     IPTVChannel channel,
   ) async {
-    final result = await ref.read(multiviewProvider.notifier).toggle(channel);
+    // AiroTvShellState's channel-list reload no longer tears this widget
+    // down on its own (see #1985), but `ref` can still momentarily go
+    // unusable from unrelated ancestor rebuilds -- this used to be a fully
+    // uncaught StateError here (silent no-op: no snackbar, no state change,
+    // confirmed on-device), which is worse than the retry itself. One short
+    // retry catches the residual race; a final failure is at least visible.
+    //
+    // Separately (confirmed on-device): opening a new session has no
+    // feedback at all while it's in flight, and a slow/dead stream can take
+    // 10+ seconds to time out and report failure -- during that whole
+    // window the toggle looks exactly like it's doing nothing. An
+    // immediate "opening" snackbar (add only; remove is effectively
+    // instant) makes that wait legible instead of looking broken.
+    final wasInMultiview = ref.read(multiviewProvider).contains(channel.id);
+    if (!wasInMultiview && context.mounted) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text('Opening ${channel.name}...'),
+            duration: const Duration(seconds: 20),
+          ),
+        );
+    }
+    MultiviewToggleResult result;
+    try {
+      result = await ref.read(multiviewProvider.notifier).toggle(channel);
+    } on StateError {
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      if (!context.mounted) return;
+      try {
+        result = await ref.read(multiviewProvider.notifier).toggle(channel);
+      } on StateError {
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            const SnackBar(
+              content: Text('Could not update multiview right now. Try again.'),
+            ),
+          );
+        return;
+      }
+    }
     if (!context.mounted) return;
     final message = switch (result) {
       MultiviewToggleResult.added => '${channel.name} added to multiview',

--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -1501,8 +1501,15 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       // removed — a vertically-centered error message can grow tall enough
       // to sit under the bottom control bar. Anchoring to the upper band
       // guarantees no collision regardless of message length.
-      child: Align(
-        alignment: Alignment.topCenter,
+      //
+      // Scrollable rather than a bare Align: on the compact embedded player
+      // (phone-width, non-fullscreen -- a fraction of screen height), this
+      // content (diagnostic overlay + up to 3 recovery buttons) can exceed
+      // the available height and hard-overflow at the bottom (confirmed
+      // on-device, "BOTTOM OVERFLOWED BY 47 PIXELS"). Scrolling degrades
+      // gracefully instead; the ample-space (fullscreen) case is unaffected
+      // since nothing needs to scroll there.
+      child: SingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.only(top: 48),
           child: Column(
@@ -2306,6 +2313,27 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
       fit: StackFit.expand,
       children: [
         Center(child: _buildCenterButton(service, state)),
+        // Isolated top-right slot, matching the conventional placement used
+        // by most video players (YouTube, Netflix, VLC): fullscreen must be
+        // easy to find and never compete for space with the bottom-edge
+        // transport/channel/settings cluster, which already gets crowded on
+        // narrow phone widths (rewind/mute/vol on one side, prev/next/
+        // random/settings on the other) -- packing a 5th-6th icon in there
+        // caused it to wrap/overlap and effectively hide behind the others.
+        if (widget.showFullscreenButton)
+          Positioned(
+            top: 12,
+            right: 12,
+            child: SafeArea(
+              bottom: false,
+              child: _PlayerFloatingControlButton(
+                key: const ValueKey('iptv-player-fullscreen-button-compact'),
+                icon: _isFullscreen ? Icons.fullscreen_exit : Icons.fullscreen,
+                tooltip: _isFullscreen ? 'Exit fullscreen' : 'Fullscreen',
+                onPressed: _toggleFullscreen,
+              ),
+            ),
+          ),
         Positioned(
           left: 12,
           bottom: 8,
@@ -2360,15 +2388,6 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
               runSpacing: 8,
               alignment: WrapAlignment.end,
               children: [
-                if (widget.showFullscreenButton)
-                  _PlayerFloatingControlButton(
-                    key: const ValueKey('iptv-player-fullscreen-button-compact'),
-                    icon: _isFullscreen
-                        ? Icons.fullscreen_exit
-                        : Icons.fullscreen,
-                    tooltip: _isFullscreen ? 'Exit fullscreen' : 'Fullscreen',
-                    onPressed: _toggleFullscreen,
-                  ),
                 if (widget.enableSwipeChannelChange) ...[
                   _PlayerFloatingControlButton(
                     key: const ValueKey('iptv-player-channel-previous-button'),


### PR DESCRIPTION
## Summary

Found via on-device testing on a physical Pixel 9 (Aika Stream, `main_tv.dart`) after #1985/#1986/#1987 landed:

- **Multiview regression**: #1986's merge simplified `_toggleMultiview` to a bare `await ... toggle(channel)` with zero error handling, trusting #1985's reload-skip fix to fully eliminate the `AiroTvShellState` ref-unmount race. Confirmed on-device it does not — the residual case is now a fully uncaught `StateError` (silent no-op). Restored a short retry + visible failure message.
- **Multiview "looks broken" (the actual root cause of the user report)**: opening a session has zero feedback while in flight, and a slow/dead stream can take 10+ seconds to time out. Traced with debug logging: the toggle was working correctly the whole time, just silently, for up to ~12 seconds before showing a (correct) failure snackbar. Added an immediate "Opening `<channel>`..." snackbar so the wait is visible instead of silent.
- **Fullscreen button crowding**: the compact/phone control row had 5-6 icons crammed into one bottom-right `Wrap` (fullscreen, prev/next channel, random, settings), confirmed on-device to visually crowd/overlap. Moved fullscreen to its own isolated top-right slot.
- **Diagnostic error overflow**: confirmed on-device (`BOTTOM OVERFLOWED BY 47 PIXELS`) — the compact embedded player's error+retry content can exceed the available height. Wrapped in `SingleChildScrollView`.

## Testing
All on a physical Pixel 9:
- Traced `_toggleMultiview` with temporary debug logging to confirm the exact failure mode (12s hang, not a crash) before implementing the fix — logging removed before commit.
- Confirmed the "Opening..." snackbar appears instantly on tap and is replaced by the real result once it resolves.
- Confirmed fullscreen button renders in the new isolated position, no longer sharing space with the crowded cluster.
- `flutter analyze` clean on both touched files.
- `flutter test` on `video_player_widget_compact_fullscreen_test.dart` + full `test/iptv/presentation/tv_ux/` suite (108 tests) — all pass, no regressions.

## Test plan
- [ ] Long-press a channel with a slow/unreliable stream, confirm "Opening..." appears immediately, then a clear added/failed message
- [ ] Confirm fullscreen icon is isolated top-right on phone-width layout, not sharing space with other controls
- [ ] Trigger a diagnostic playback error on the embedded (non-fullscreen) player, confirm no overflow banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)