### PR TITLE
docs(tv): fix stale onPlaylistSourceTap doc comment

### DIFF
--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -65,8 +65,11 @@ class AiroTvShell extends ConsumerStatefulWidget {
   final Map<String, StreamAvailability> availabilityByChannelId;
   final bool enrichMetadata;
 
-  /// Opens the playlist-source sheet from the LIVE bar. Wired on TV where
-  /// the phone app bar is suppressed; null hides the entry.
+  /// Opens the playlist-source sheet from the LIVE bar. Consumed by
+  /// [ChannelInfoBar] on the grid-first ten-foot layout (`!showVideoStage`);
+  /// wired on TV where the phone app bar is suppressed. Null hides the
+  /// entry. The Explorer-rows settings dialog offers an equivalent
+  /// "Playlist source" row, wired independently from `iptv_screen.dart`.
   final VoidCallback? onPlaylistSourceTap;
 
   /// Enters the fullscreen player. Lives on the stage's own action row (not


### PR DESCRIPTION
## Summary
- Fixes stale doc comment on `AiroTvShell.onPlaylistSourceTap` that claimed the callback was unconsumed
- Callback is actively consumed by `ChannelInfoBar` on the grid-first ten-foot layout
- Notes the Explorer-rows settings dialog now offers an equivalent "Playlist source" row, wired independently from `iptv_screen.dart`

## Test plan
- [x] Doc-only change, no behavior change
- [x] Verified current wiring by reading `airo_tv_shell.dart` and `iptv_screen.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)