### PR TITLE
fix(tv): pin diagnostic error box to full player height

### DIFF
--- a/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
+++ b/packages/feature_iptv/lib/presentation/widgets/video_player_widget.dart
@@ -1018,10 +1018,21 @@ class _VideoPlayerWidgetState extends ConsumerState<VideoPlayerWidget> {
     final playerSurface = Stack(
       alignment: Alignment.center,
       children: [
+        // #1989 swapped the diagnostic error's inner Align(topCenter) for a
+        // SingleChildScrollView (to stop bottom overflow on compact
+        // players), but a scroll view shrink-wraps to its content instead
+        // of filling available space -- so the surrounding
+        // Stack(alignment: Alignment.center) started vertically centering
+        // the whole (now content-sized) error box instead of it spanning
+        // the full player height. Positioned.fill restores that full-height
+        // frame so the box's own top-anchored padding still lands in the
+        // upper band.
         if (hasPlaybackError)
-          state.diagnostic != null
-              ? _buildDiagnosticError(state)
-              : _buildError(state.errorMessage ?? 'Playback could not start.')
+          Positioned.fill(
+            child: state.diagnostic != null
+                ? _buildDiagnosticError(state)
+                : _buildError(state.errorMessage ?? 'Playback could not start.'),
+          )
         else if (state.isLoading)
           _buildLoading()
         else if (_isAudioOnly)


### PR DESCRIPTION
## Summary
- #1989 swapped the diagnostic error's inner `Align(topCenter)` for a `SingleChildScrollView` to stop bottom overflow on compact players, but a scroll view shrink-wraps to its content instead of filling available space.
- That let the surrounding `Stack(alignment: Alignment.center)` vertically center the now content-sized error box instead of it spanning the full player height, pushing the diagnostic message below the intended upper band (measured 256px vs required <162px in the 540px test viewport).
- Wraps the error branch in `Positioned.fill` so it keeps the scroll-view overflow fix while restoring the full-height frame the top-anchored padding relies on.

## Test plan
- [x] `flutter test test/presentation/widgets/video_player_widget_error_layout_test.dart` — all 11 tests pass (was 1 failing)
- [x] `flutter test` (full `feature_iptv` suite) — 946/947 pass; the one remaining failure (`iptv_screen_ten_foot_fullscreen_test.dart`) confirmed pre-existing and unrelated by reverting the fix and re-running in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)