### PR TITLE
fix(iptv): critical/important fixes from TV player revamp post-merge review

### DIFF
--- a/app/test/core/app/tv_router_test.dart
+++ b/app/test/core/app/tv_router_test.dart
@@ -2,7 +2,6 @@ import 'package:airo_app/core/app/tv_router.dart';
 import 'package:airo_app/core/platform/device_form_factor.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:feature_iptv/feature_iptv.dart';
-import 'package:feature_iptv/presentation/tv_ux/sections/bottom_nav_bar.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/app/test/core/routing/guide_back_behavior_test.dart
+++ b/app/test/core/routing/guide_back_behavior_test.dart
@@ -1,0 +1,139 @@
+import 'package:airo_app/core/routing/app_router.dart';
+import 'package:airo_app/main.dart';
+import 'package:feature_iptv/feature_iptv.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  final fixedNow = DateTime.utc(2026, 7, 21, 12);
+
+  const channels = [
+    IPTVChannel(
+      id: 'news-1',
+      name: 'City News Live',
+      streamUrl: 'https://example.com/news.m3u8',
+      group: 'News',
+      category: ChannelCategory.news,
+    ),
+    IPTVChannel(
+      id: 'sports-1',
+      name: 'Stadium Sports',
+      streamUrl: 'https://example.com/sports.m3u8',
+      group: 'Sports',
+      category: ChannelCategory.sports,
+    ),
+  ];
+
+  Future<GoRouter> pumpApp(
+    WidgetTester tester, {
+    String initialLocation = '/iptv',
+  }) async {
+    SharedPreferences.setMockInitialValues({'is_logged_in': true});
+    final prefs = await SharedPreferences.getInstance();
+    final router = AppRouter.createRouter(
+      moduleRegistry: buildMainModuleRegistry(),
+      initialLocation: initialLocation,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          iptvChannelsProvider.overrideWith((ref) async => channels),
+          streamingStateProvider.overrideWith(
+            (ref) => Stream.value(
+              StreamingState(
+                playbackState: PlaybackState.idle,
+                isLiveStream: true,
+              ),
+            ),
+          ),
+          recentlyWatchedChannelsProvider.overrideWith((ref) async => const []),
+          favoriteChannelIdsProvider.overrideWith((ref) async => const []),
+          hiddenGroupIdsProvider.overrideWith((ref) async => const {}),
+          guidePagedWindowProvider.overrideWith(
+            () => _FakePagedNotifier(
+              GuidePagedWindowState(
+                earliestStart: fixedNow.subtract(const Duration(minutes: 30)),
+                loadedThrough: fixedNow.add(const Duration(hours: 3)),
+                window: CompactEpgWindow(
+                  entries: const [],
+                  windowStart: fixedNow.subtract(const Duration(minutes: 30)),
+                  windowEnd: fixedNow.add(const Duration(hours: 3)),
+                  generatedAt: fixedNow,
+                  expiresAt: fixedNow.add(const Duration(hours: 1)),
+                  source: CompactEpgSliceSource.unavailable,
+                ),
+              ),
+            ),
+          ),
+          nowTickerProvider.overrideWith((ref) => Stream.value(fixedNow)),
+          epgRemindersProvider.overrideWith((ref) async => const []),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    return router;
+  }
+
+  // Guide is no longer reachable from a hamburger drawer (deleted along with
+  // the drawer's AppBar menu icon in the bottom-nav revamp): it now lives as
+  // a row in the "My Aika" bottom-nav overflow sheet
+  // (IptvBottomNavBar -> IPTVScreen._showMyAikaSheet -> IPTVScreen._openGuide),
+  // pushed with a plain Navigator.push on the IPTV screen's own Navigator.
+  // The GoRouter location therefore stays at '/iptv' throughout.
+  Future<void> openGuideFromMyAikaSheet(WidgetTester tester) async {
+    await tester.tap(find.text('My Aika'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Guide'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('opening Guide from the My Aika sheet renders the guide screen', (
+    tester,
+  ) async {
+    final router = await pumpApp(tester);
+
+    await openGuideFromMyAikaSheet(tester);
+
+    expect(_currentPath(router), '/iptv');
+    expect(find.text('Search the guide'), findsOneWidget);
+  });
+
+  testWidgets('system back on a pushed guide screen returns to IPTV', (
+    tester,
+  ) async {
+    final router = await pumpApp(tester);
+
+    await openGuideFromMyAikaSheet(tester);
+    expect(find.text('Search the guide'), findsOneWidget);
+
+    final didPop = await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(didPop, isTrue);
+    expect(_currentPath(router), '/iptv');
+    expect(find.text('Search the guide'), findsNothing);
+    expect(find.byType(Scaffold), findsAtLeastNWidgets(1));
+  });
+}
+
+String _currentPath(GoRouter router) {
+  return router.routerDelegate.currentConfiguration.uri.path;
+}
+
+class _FakePagedNotifier extends GuidePagedWindowNotifier {
+  _FakePagedNotifier(this._state);
+
+  final GuidePagedWindowState _state;
+
+  @override
+  GuidePagedWindowState build() => _state;
+}

--- a/packages/feature_iptv/lib/feature_iptv.dart
+++ b/packages/feature_iptv/lib/feature_iptv.dart
@@ -69,6 +69,7 @@ export "presentation/tv/settings/tv_source_management_section.dart";
 export "presentation/tv_ux/iptv_resume_gate.dart";
 export "presentation/tv_ux/iptv_resume_splash.dart";
 export "presentation/tv_ux/airo_tv_shell.dart";
+export "presentation/tv_ux/sections/bottom_nav_bar.dart";
 export "presentation/tv/tv_favorites_screen.dart";
 export "presentation/tv/vod_tv_screen.dart";
 export "presentation/widgets/cast_device_picker_sheet.dart";

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -30,6 +30,7 @@ import '../widgets/playlist_source_manager_sheet.dart';
 import '../widgets/tv_playlist_qr_dialog.dart';
 import '../widgets/video_player_widget.dart';
 import '../widgets/xmltv_source_sheet.dart';
+import '../tv/iptv_guide_screen.dart';
 import '../tv_ux/airo_tv_shell.dart';
 import '../tv_ux/iptv_resume_gate.dart';
 import '../tv_ux/sections/ways_to_watch_dialog.dart';
@@ -799,10 +800,9 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
 
   /// The bottom nav's "My Aika" destination: an overflow sheet for the
   /// destinations that used to live in the (now-deleted) hamburger drawer —
-  /// Home and Guide are gone from the set (Home is now its own bottom-nav
-  /// destination and Guide is not part of this revamp's navigation), but
-  /// Settings, Movies & Shows, Favorites, and Play local file on TV keep
-  /// the same conditional-null-hides-item visibility the drawer had.
+  /// Home is gone from the set (it is now its own bottom-nav destination),
+  /// but Guide, Settings, Movies & Shows, Favorites, and Play local file on
+  /// TV keep the same conditional-null-hides-item visibility the drawer had.
   Future<void> _showMyAikaSheet() {
     return showAdaptiveIptvSheet<void>(
       context: context,
@@ -810,6 +810,15 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            ListTile(
+              key: const ValueKey('iptv-my-aika-guide'),
+              leading: const Icon(Icons.grid_view_outlined),
+              title: const Text('Guide'),
+              onTap: () {
+                Navigator.of(sheetContext).pop();
+                _openGuide();
+              },
+            ),
             if (widget.onSettings != null)
               ListTile(
                 key: const ValueKey('iptv-my-aika-settings'),
@@ -850,6 +859,18 @@ class _IPTVScreenState extends ConsumerState<IPTVScreen>
                 },
               ),
           ],
+        ),
+      ),
+    );
+  }
+
+  /// Pushes the full-screen EPG program guide on this screen's own
+  /// Navigator, mirroring the pattern the deleted hamburger drawer used.
+  Future<void> _openGuide() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => IptvGuideScreen(
+          onChannelSelected: () => Navigator.of(context).pop(),
         ),
       ),
     );

--- a/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
+++ b/packages/feature_iptv/lib/presentation/screens/iptv_screen.dart
@@ -1631,7 +1631,7 @@ class _StreamTabContent extends ConsumerWidget {
   /// has a guide-source entry point of its own.
   final VoidCallback? onGuideSourceTap;
   final VoidCallback onScanWithPhoneTap;
-  final VoidCallback onWaysToWatchTap;
+  final Future<void> Function() onWaysToWatchTap;
   final Future<void> Function(Uint8List pngBytes)? onShareVideoFrame;
 
   /// True on TV (no app bar): surfaces the playlist-source entry in the

--- a/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/airo_tv_shell.dart
@@ -90,7 +90,12 @@ class AiroTvShell extends ConsumerStatefulWidget {
   /// This only reaches layouts that actually draw a stage: the grid-first
   /// ten-foot layout (`showVideoStage: false`) renders no action row, so it
   /// currently has no Ways to Watch entry point at all.
-  final VoidCallback? onWaysToWatchTap;
+  ///
+  /// Typed as returning a `Future<void>` (rather than a plain [VoidCallback])
+  /// so the stage action row can wrap its invocation in [_whileSheetOpen] —
+  /// it opens a modal dialog just like Settings/Help/Layout, and needs the
+  /// same overlay-dismiss tracking for the same reason.
+  final Future<void> Function()? onWaysToWatchTap;
 
   /// Host-owned delivery for a frame-only PNG capture.
   final Future<void> Function(Uint8List pngBytes)? onShareVideoFrame;
@@ -323,8 +328,10 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
                   ),
             onScreenshot: widget.onShareVideoFrame == null
                 ? null
-                : () => _captureVideoFrame(context),
-            onWaysToWatch: widget.onWaysToWatchTap,
+                : () => _whileSheetOpen(_captureVideoFrame(context)),
+            onWaysToWatch: widget.onWaysToWatchTap == null
+                ? null
+                : () => _whileSheetOpen(widget.onWaysToWatchTap!()),
             child: KeyedSubtree(
               key: const ValueKey('airo-tv-video-capture-scope'),
               child: RepaintBoundary(
@@ -583,14 +590,17 @@ class _AiroTvShellState extends ConsumerState<AiroTvShell> {
           if (!context.mounted) return;
           final replaceMessage = switch (replaceResult) {
             MultiviewToggleResult.added => '${channel.name} added to multiview',
-            MultiviewToggleResult.failed =>
+            // replace() only frees a slot if `oldChannelId` is still actually
+            // in the pool at call time. If that session already ended on its
+            // own while the dialog was open, no slot is freed and
+            // capacityReached is exactly what comes back -- give it the same
+            // feedback as failed rather than silently doing nothing.
+            MultiviewToggleResult.failed ||
+            MultiviewToggleResult.capacityReached =>
               '${channel.name} could not be opened in multiview.',
-            // added/failed are the only results replace() can return here:
-            // it never reports removed (replace never removes without also
-            // adding), and it can't recur into capacityReached since a slot
-            // was just freed before the add was attempted.
-            MultiviewToggleResult.removed ||
-            MultiviewToggleResult.capacityReached => null,
+            // replace() never reports removed: it never removes without also
+            // adding.
+            MultiviewToggleResult.removed => null,
           };
           if (replaceMessage == null) return;
           ScaffoldMessenger.of(context)

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/bottom_nav_bar.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/bottom_nav_bar.dart
@@ -30,9 +30,17 @@ class IptvBottomNavBar extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            _Destination(icon: Icons.home_outlined, label: 'Home', onTap: onHome),
+            _Destination(
+              icon: Icons.home_outlined,
+              label: 'Home',
+              onTap: onHome,
+            ),
             _Destination(icon: Icons.search, label: 'Search', onTap: onSearch),
-            _Destination(icon: Icons.auto_awesome_outlined, label: 'My Aika', onTap: onMyAika),
+            _Destination(
+              icon: Icons.auto_awesome_outlined,
+              label: 'My Aika',
+              onTap: onMyAika,
+            ),
           ],
         ),
       ),
@@ -41,7 +49,11 @@ class IptvBottomNavBar extends StatelessWidget {
 }
 
 class _Destination extends StatelessWidget {
-  const _Destination({required this.icon, required this.label, required this.onTap});
+  const _Destination({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
 
   final IconData icon;
   final String label;
@@ -63,7 +75,10 @@ class _Destination extends StatelessWidget {
             children: [
               Icon(icon, color: Colors.white, size: 22),
               const SizedBox(height: 2),
-              Text(label, style: const TextStyle(color: Colors.white, fontSize: 11)),
+              Text(
+                label,
+                style: const TextStyle(color: Colors.white, fontSize: 11),
+              ),
             ],
           ),
         ),

--- a/packages/feature_iptv/lib/presentation/tv_ux/sections/multiview_stage.dart
+++ b/packages/feature_iptv/lib/presentation/tv_ux/sections/multiview_stage.dart
@@ -250,7 +250,8 @@ class _PromotableSurfaceState extends State<_PromotableSurface> {
               widget.onSwap == null
           ? null
           : () => widget.onSwap?.call(widget.featuredChannelId!, session.id),
-      onSecondaryAction: () => _showTileControls(context, session),
+      onSecondaryAction: () =>
+          _showTileControls(context, session, onDismiss: widget.onDismiss),
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: () => widget.onPromote(session.id),
@@ -313,8 +314,9 @@ class _DismissTileButton extends StatelessWidget {
 
 Future<void> _showTileControls(
   BuildContext context,
-  IptvMultiviewSession session,
-) {
+  IptvMultiviewSession session, {
+  ValueChanged<String>? onDismiss,
+}) {
   return showDialog<void>(
     context: context,
     builder: (context) => StreamBuilder<StreamingState>(
@@ -404,6 +406,20 @@ Future<void> _showTileControls(
                 onPressed: () => session.setQuality(quality),
                 child: Text(quality.name),
               ),
+            if (onDismiss != null) ...[
+              const Divider(height: 24),
+              SimpleDialogOption(
+                key: ValueKey('multiview-remove-${session.id}'),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  onDismiss(session.id);
+                },
+                child: Text(
+                  'Remove from MultiView',
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ),
+            ],
           ],
         );
       },

--- a/packages/feature_iptv/test/iptv/application/providers/guide_providers_test.dart
+++ b/packages/feature_iptv/test/iptv/application/providers/guide_providers_test.dart
@@ -188,9 +188,7 @@ void main() {
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
           iptvChannelsProvider.overrideWith((ref) async => [channel, other]),
-          favoriteChannelIdsProvider.overrideWith(
-            (ref) async => ['channel-2'],
-          ),
+          favoriteChannelIdsProvider.overrideWith((ref) async => ['channel-2']),
         ],
       );
       addTearDown(container.dispose);

--- a/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/screens/iptv_screen_test.dart
@@ -3,7 +3,6 @@ import "package:feature_iptv/application/channel_metadata_enrichment.dart";
 import "package:feature_iptv/application/providers/multiview_provider.dart"
     show multiviewDecoderBudgetProvider;
 import "package:feature_iptv/feature_iptv.dart";
-import 'package:feature_iptv/presentation/tv_ux/sections/bottom_nav_bar.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/airo_tv_shell_test.dart
@@ -60,7 +60,7 @@ void main() {
     StreamingState? streamingState,
     Future<void> Function(Uint8List)? onShareVideoFrame,
     Future<Uint8List> Function(RenderRepaintBoundary)? videoFrameEncoder,
-    VoidCallback? onWaysToWatchTap,
+    Future<void> Function()? onWaysToWatchTap,
   }) async {
     final prefs = await SharedPreferences.getInstance();
     final container = ProviderContainer(
@@ -430,7 +430,9 @@ void main() {
         1280,
         showVideoStage: false,
         currentChannel: channels.first,
-        onWaysToWatchTap: () => waysToWatchTapped = true,
+        onWaysToWatchTap: () async {
+          waysToWatchTapped = true;
+        },
       );
       await tester.pumpAndSettle();
 
@@ -509,6 +511,94 @@ void main() {
       isFalse,
     );
   });
+
+  testWidgets(
+    'opening Ways to Watch dismisses the overlay for as long as the dialog '
+    'is open -- the same translucent-hit-test re-reveal bug Settings/Help/ '
+    'Layout already avoid',
+    (tester) async {
+      final waysToWatchOpen = Completer<void>();
+      await pumpAt(
+        tester,
+        1280,
+        currentChannel: channels.first,
+        onWaysToWatchTap: () => waysToWatchOpen.future,
+      );
+      await tester.pump();
+      expect(
+        tester
+            .widget<ChannelNameOverlay>(find.byType(ChannelNameOverlay))
+            .dismissRequested,
+        isFalse,
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('airo-tv-shell-ways-to-watch-action')),
+      );
+      await tester.pump();
+
+      expect(
+        tester
+            .widget<ChannelNameOverlay>(find.byType(ChannelNameOverlay))
+            .dismissRequested,
+        isTrue,
+      );
+
+      waysToWatchOpen.complete();
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<ChannelNameOverlay>(find.byType(ChannelNameOverlay))
+            .dismissRequested,
+        isFalse,
+      );
+    },
+  );
+
+  testWidgets(
+    'opening the screenshot capture dismisses the overlay for as long as it '
+    'is in flight',
+    (tester) async {
+      final encoding = Completer<Uint8List>();
+      await pumpAt(
+        tester,
+        1280,
+        currentChannel: channels.first,
+        onShareVideoFrame: (_) async {},
+        videoFrameEncoder: (_) => encoding.future,
+      );
+      await tester.pump();
+      expect(
+        tester
+            .widget<ChannelNameOverlay>(find.byType(ChannelNameOverlay))
+            .dismissRequested,
+        isFalse,
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('airo-tv-shell-screenshot-action')),
+      );
+      await tester.pump();
+
+      expect(
+        tester
+            .widget<ChannelNameOverlay>(find.byType(ChannelNameOverlay))
+            .dismissRequested,
+        isTrue,
+      );
+
+      encoding.complete(Uint8List(0));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<ChannelNameOverlay>(find.byType(ChannelNameOverlay))
+            .dismissRequested,
+        isFalse,
+      );
+    },
+  );
 
   testWidgets('the filter row seeds D-pad focus now the LIVE bar is gone', (
     tester,
@@ -671,6 +761,81 @@ void main() {
       expect(ids, ['two']);
       expect(sessions['one']!.closed, isTrue);
       expect(find.text('Two added to multiview'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'replace() returning capacityReached (the picked slot already freed '
+    'itself before the tap landed) still surfaces feedback instead of '
+    'silently doing nothing',
+    (tester) async {
+      final primary = _FakeMultiviewPrimaryService();
+      final sessions = <String, _FakeMultiviewSession>{};
+      final controller = _CapacityForcingMultiviewController(
+        decoderBudget: 1,
+        primaryService: primary,
+        sessionFactory: (item) async =>
+            sessions.putIfAbsent(item.id, () => _FakeMultiviewSession(item)),
+      );
+      addTearDown(controller.close);
+      // Fill the single-stream capacity with 'one' before the shell mounts,
+      // so the replace dialog has a slot to offer.
+      await controller.toggle(channels[0]);
+
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          streamProbeTransportProvider.overrideWithValue(_FakeProbeTransport()),
+          isOnlineProvider.overrideWith((ref) => Stream.value(true)),
+          multiviewProvider.overrideWith((ref) => controller),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 1280,
+                height: 720,
+                child: AiroTvShell(
+                  channels: channels,
+                  videoStage: const SizedBox(key: ValueKey('video-stage')),
+                  onChannelSelected: (_) {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      tester
+          .widget<ChannelLibraryGrid>(find.byType(ChannelLibraryGrid))
+          .onMultiviewToggle!(channels[1]);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('airo-tv-multiview-replace-dialog')),
+        findsOneWidget,
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('multiview-replace-slot-one')),
+      );
+      await tester.pumpAndSettle();
+
+      // _CapacityForcingMultiviewController.replace() always answers
+      // capacityReached, simulating the freed-then-refilled-slot race the
+      // real replace() can hit. Before the fix this branch mapped to `null`
+      // and showed nothing at all.
+      expect(
+        find.text('Two could not be opened in multiview.'),
+        findsOneWidget,
+      );
     },
   );
 
@@ -962,6 +1127,24 @@ class _FakeMultiviewSession implements IptvMultiviewSession {
     closed = true;
     await _states.close();
   }
+}
+
+/// Real pool/session plumbing (so the replace dialog has real sessions to
+/// render), but [replace] always answers `capacityReached` -- standing in
+/// for the real race where `oldChannelId` already left the pool by itself
+/// before the tap landed, so no slot got freed and the pool is still full.
+class _CapacityForcingMultiviewController extends MultiviewController {
+  _CapacityForcingMultiviewController({
+    required super.decoderBudget,
+    required super.sessionFactory,
+    required super.primaryService,
+  });
+
+  @override
+  Future<MultiviewToggleResult> replace(
+    String oldChannelId,
+    IPTVChannel newChannel,
+  ) async => MultiviewToggleResult.capacityReached;
 }
 
 class _FakeMultiviewPrimaryService implements IPTVStreamingService {

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/bottom_nav_bar_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/bottom_nav_bar_test.dart
@@ -4,11 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   Widget wrap(Widget child) {
-    return MaterialApp(
-      home: Scaffold(
-        body: child,
-      ),
-    );
+    return MaterialApp(home: Scaffold(body: child));
   }
 
   testWidgets('renders Home, Search, My Aika destinations', (tester) async {

--- a/packages/feature_iptv/test/iptv/presentation/tv_ux/multiview_stage_test.dart
+++ b/packages/feature_iptv/test/iptv/presentation/tv_ux/multiview_stage_test.dart
@@ -277,6 +277,93 @@ void main() {
   );
 
   testWidgets(
+    'Menu key (D-pad) opens tile controls with a Remove option that calls '
+    'onDismiss',
+    (tester) async {
+      final sessions = [session('one'), session('two')];
+      addTearDown(() => Future.wait(sessions.map((item) => item.close())));
+      String? dismissed;
+      await pump(tester, sessions, onDismiss: (id) => dismissed = id);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('multiview-controls-one')),
+        findsOneWidget,
+      );
+      final removeOption = find.byKey(const ValueKey('multiview-remove-one'));
+      expect(removeOption, findsOneWidget);
+
+      // The dialog's option list overflows the default 800x600 test
+      // surface, so the Remove row starts out below the fold inside
+      // SimpleDialog's own scroll view -- scroll it into view before tapping.
+      await tester.ensureVisible(removeOption);
+      await tester.pumpAndSettle();
+      await tester.tap(removeOption);
+      await tester.pumpAndSettle();
+
+      expect(dismissed, 'one');
+      // The dialog closes after Remove is chosen.
+      expect(
+        find.byKey(const ValueKey('multiview-controls-one')),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'long-press (touch) opens tile controls with a Remove option that calls '
+    'onDismiss -- proves the dismiss path works without D-pad focus',
+    (tester) async {
+      final sessions = [session('one'), session('two')];
+      addTearDown(() => Future.wait(sessions.map((item) => item.close())));
+      String? dismissed;
+      await pump(tester, sessions, onDismiss: (id) => dismissed = id);
+
+      // No keyboard/D-pad focus at all -- the corner dismiss button never
+      // renders for a touch-only user. Long-press is the touch equivalent
+      // of the remote's Menu key (TvFocusable wires onLongPress to the same
+      // onSecondaryAction callback as TvInputKey.menu).
+      expect(find.byKey(const ValueKey('multiview-dismiss-one')), findsNothing);
+
+      await tester.longPress(
+        find.byKey(const ValueKey('multiview-promote-one')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('multiview-controls-one')),
+        findsOneWidget,
+      );
+
+      final removeOption = find.byKey(const ValueKey('multiview-remove-one'));
+      await tester.ensureVisible(removeOption);
+      await tester.pumpAndSettle();
+      await tester.tap(removeOption);
+      await tester.pumpAndSettle();
+
+      expect(dismissed, 'one');
+    },
+  );
+
+  testWidgets(
+    'tile controls dialog omits Remove when onDismiss is not supplied',
+    (tester) async {
+      final sessions = [session('one'), session('two')];
+      addTearDown(() => Future.wait(sessions.map((item) => item.close())));
+      await pump(tester, sessions);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.sendKeyEvent(LogicalKeyboardKey.contextMenu);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('multiview-remove-one')), findsNothing);
+    },
+  );
+
+  testWidgets(
     'empty slot is focusable and calls onEmptySlotTap when selected',
     (tester) async {
       final sessions = [session('one'), session('two')];

--- a/packages/platform_favorites/lib/src/favorite_channels_storage.dart
+++ b/packages/platform_favorites/lib/src/favorite_channels_storage.dart
@@ -98,8 +98,12 @@ class FavoriteChannelsStorage {
   }
 
   /// Replaces the complete favorite list for an import/restore operation,
-  /// preserving the given order. Does not touch not-for-me state.
-  Future<void> replaceAll(Iterable<String> channelIds) {
+  /// preserving the given order. Also removes every (re)added id from the
+  /// not-for-me set, mirroring [setFavorite]'s single-id exclusion -- without
+  /// this, restoring a backup containing a channel the user has since marked
+  /// not-for-me would leave that channel in both sets at once, violating this
+  /// class's own mutually-exclusive-by-construction invariant.
+  Future<void> replaceAll(Iterable<String> channelIds) async {
     final normalized = <String>[];
     final seen = <String>{};
     for (final id in channelIds) {
@@ -107,7 +111,15 @@ class FavoriteChannelsStorage {
       if (trimmed.isEmpty || !seen.add(trimmed)) continue;
       normalized.add(trimmed);
     }
-    return _saveFavorites(normalized);
+    final notForMe = await getNotForMeChannelIds();
+    final notForMeChanged = normalized.fold(
+      false,
+      (changed, id) => notForMe.remove(id) || changed,
+    );
+    await Future.wait([
+      _saveFavorites(normalized),
+      if (notForMeChanged) _saveNotForMe(notForMe),
+    ]);
   }
 
   Future<void> _saveFavorites(List<String> ids) {

--- a/packages/platform_favorites/test/favorite_channels_storage_test.dart
+++ b/packages/platform_favorites/test/favorite_channels_storage_test.dart
@@ -71,32 +71,36 @@ void main() {
     expect(await reloaded.getFavoriteChannelIds(), ['news']);
   });
 
-  test('setFavorite clears an existing not-for-me flag on the same channel',
-      () async {
-    SharedPreferences.setMockInitialValues({});
-    final prefs = await SharedPreferences.getInstance();
-    final storage = FavoriteChannelsStorage(prefs);
-    await storage.setNotForMe('ch1');
-    expect(await storage.isNotForMe('ch1'), isTrue);
+  test(
+    'setFavorite clears an existing not-for-me flag on the same channel',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final storage = FavoriteChannelsStorage(prefs);
+      await storage.setNotForMe('ch1');
+      expect(await storage.isNotForMe('ch1'), isTrue);
 
-    await storage.setFavorite('ch1');
+      await storage.setFavorite('ch1');
 
-    expect(await storage.isFavorite('ch1'), isTrue);
-    expect(await storage.isNotForMe('ch1'), isFalse);
-  });
+      expect(await storage.isFavorite('ch1'), isTrue);
+      expect(await storage.isNotForMe('ch1'), isFalse);
+    },
+  );
 
-  test('setNotForMe clears an existing favorite flag on the same channel',
-      () async {
-    SharedPreferences.setMockInitialValues({});
-    final prefs = await SharedPreferences.getInstance();
-    final storage = FavoriteChannelsStorage(prefs);
-    await storage.setFavorite('ch1');
+  test(
+    'setNotForMe clears an existing favorite flag on the same channel',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final storage = FavoriteChannelsStorage(prefs);
+      await storage.setFavorite('ch1');
 
-    await storage.setNotForMe('ch1');
+      await storage.setNotForMe('ch1');
 
-    expect(await storage.isNotForMe('ch1'), isTrue);
-    expect(await storage.isFavorite('ch1'), isFalse);
-  });
+      expect(await storage.isNotForMe('ch1'), isTrue);
+      expect(await storage.isFavorite('ch1'), isFalse);
+    },
+  );
 
   test('getFavoriteChannelIds preserves insertion order', () async {
     SharedPreferences.setMockInitialValues({});
@@ -109,16 +113,18 @@ void main() {
     expect(await storage.getFavoriteChannelIds(), ['ch3', 'ch1', 'ch2']);
   });
 
-  test('setFavorite is a no-op dedup when the channel is already favorited',
-      () async {
-    SharedPreferences.setMockInitialValues({});
-    final prefs = await SharedPreferences.getInstance();
-    final storage = FavoriteChannelsStorage(prefs);
-    await storage.setFavorite('ch1');
-    await storage.setFavorite('ch1');
+  test(
+    'setFavorite is a no-op dedup when the channel is already favorited',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final storage = FavoriteChannelsStorage(prefs);
+      await storage.setFavorite('ch1');
+      await storage.setFavorite('ch1');
 
-    expect(await storage.getFavoriteChannelIds(), ['ch1']);
-  });
+      expect(await storage.getFavoriteChannelIds(), ['ch1']);
+    },
+  );
 
   test('replaceAll preserves the order of the provided iterable', () async {
     SharedPreferences.setMockInitialValues({});
@@ -127,5 +133,37 @@ void main() {
     await storage.replaceAll(['chB', 'chA', 'chC']);
 
     expect(await storage.getFavoriteChannelIds(), ['chB', 'chA', 'chC']);
+  });
+
+  test('replaceAll clears not-for-me for every restored id, preserving the '
+      'mutually-exclusive invariant', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final storage = FavoriteChannelsStorage(prefs);
+    // The user marked 'chA' not-for-me locally, then restores a backup
+    // that favorites 'chA' again.
+    await storage.setNotForMe('chA');
+    await storage.setNotForMe('chB');
+
+    await storage.replaceAll(['chA', 'chC']);
+
+    expect(await storage.getFavoriteChannelIds(), ['chA', 'chC']);
+    // 'chA' is now a favorite again, so it must leave the not-for-me set.
+    expect(await storage.isNotForMe('chA'), isFalse);
+    // 'chB' was never part of the restored favorites, so its not-for-me
+    // flag is untouched.
+    expect(await storage.isNotForMe('chB'), isTrue);
+  });
+
+  test('replaceAll is a no-op on not-for-me when none of the restored ids '
+      'overlap it', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final storage = FavoriteChannelsStorage(prefs);
+    await storage.setNotForMe('chB');
+
+    await storage.replaceAll(['chA']);
+
+    expect(await storage.isNotForMe('chB'), isTrue);
   });
 }


### PR DESCRIPTION
## Summary

PR #1995 (TV player premium UX revamp) merged before its own final whole-branch review finished. That review found 2 Critical regressions and 5 Important issues, all fixed on the original branch but never pushed forward into a PR. This carries those 6 commits onto current `main`.

- **Critical:** EPG Guide screen unreachable on phone/tablet — the bottom-nav revamp deleted `_openGuide` and the drawer's Guide entry with no replacement. Restored via a Guide row in the My Aika sheet.
- **Critical:** MultiView per-tile dismiss unreachable by touch or D-pad — the corner dismiss button only ever renders on keyboard/mouse hover focus. Added a "Remove from MultiView" option to the existing tile-controls dialog (reachable via D-pad Menu and long-press).
- **Important:** Ways-to-Watch/Screenshot dialogs didn't dismiss the channel-name overlay underneath them, unlike Settings/Help/Layout.
- **Important:** `MultiviewController.replace()`'s `capacityReached` outcome produced no user feedback (silent failure) on a freed-then-refilled-slot race.
- **Important:** `FavoriteChannelsStorage.replaceAll` (backup restore) didn't clear restored ids from the not-for-me set, breaking the favorite/not-for-me mutual-exclusion invariant.
- **Housekeeping:** `IptvBottomNavBar` now exported from the `feature_iptv` barrel (was forcing a deep cross-package import); `dart format` applied to the branch-introduced files.

Full root-cause analysis and test rationale for each fix: see `.superpowers/sdd/2026-09-11-tv-player-premium-revamp/final-review-fix-report.md`.

## Test plan
- [x] `flutter test` — `packages/feature_iptv`: 990/990 passed
- [x] `flutter test` — `packages/platform_favorites`: 19/19 passed
- [x] `flutter test test/core/routing/guide_back_behavior_test.dart` (app/): 4/4 passed
- [x] `flutter test test/core/app/tv_router_test.dart` (app/): 18/18 passed
- [x] `flutter analyze` — `packages/feature_iptv`: 5 pre-existing issues only, unrelated files
- [x] `flutter analyze` — `packages/platform_favorites`: no issues
- [x] `dart format --set-exit-if-changed` scoped to touched files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)