### PR TITLE
feat(anya): bind PlanRepairPort to on-device GGUF

### DIFF
--- a/app/lib/anya/anya_gguf_path.dart
+++ b/app/lib/anya/anya_gguf_path.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+/// Resolves a local GGUF for Anya repair. Never downloads.
+///
+/// [configuredPath] wins when non-empty (`ANYA_GGUF_PATH` dart-define in
+/// production). A configured path that does not exist returns null — it does
+/// not fall through to [searchRoots].
+String? resolveAnyaGgufPath({
+  String? configuredPath,
+  Iterable<Directory> searchRoots = const [],
+}) {
+  final configured =
+      (configuredPath ?? const String.fromEnvironment('ANYA_GGUF_PATH')).trim();
+  if (configured.isNotEmpty) {
+    final file = File(configured);
+    return file.existsSync() ? file.path : null;
+  }
+  for (final root in searchRoots) {
+    if (!root.existsSync()) continue;
+    final matches =
+        root
+            .listSync(recursive: true, followLinks: false)
+            .whereType<File>()
+            .where((file) => file.path.toLowerCase().endsWith('.gguf'))
+            .toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
+    if (matches.isNotEmpty) return matches.first.path;
+  }
+  return null;
+}

--- a/app/lib/anya/anya_plan_repair_factory_io.dart
+++ b/app/lib/anya/anya_plan_repair_factory_io.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:core_completion/core_completion.dart';
+import 'package:feature_anya/feature_anya.dart';
+import 'package:flutter/foundation.dart';
+import 'package:llama_flutter_android/llama_flutter_android.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'anya_gguf_path.dart';
+import 'gguf_plan_repair_port.dart';
+
+typedef AnyaGgufBinder = Future<PlanRepairPort?> Function(String modelPath);
+
+Future<List<Directory>> defaultAnyaGgufSearchRoots() async {
+  final support = await getApplicationSupportDirectory();
+  final docs = await getApplicationDocumentsDirectory();
+  return [Directory('${support.path}/models'), support, docs];
+}
+
+/// IO factory: GGUF on Android, otherwise [NoopPlanRepairPort].
+Future<PlanRepairPort> createAnyaPlanRepairPort({
+  CompletionClient? completion,
+  String? configuredPath,
+  Iterable<Directory>? searchRoots,
+  AnyaGgufBinder? bindModel,
+}) async {
+  if (completion != null) {
+    return GgufPlanRepairPort(completion);
+  }
+  final configured =
+      (configuredPath ?? const String.fromEnvironment('ANYA_GGUF_PATH')).trim();
+  final path = resolveAnyaGgufPath(
+    configuredPath: configuredPath,
+    searchRoots:
+        searchRoots ??
+        (configured.isEmpty
+            ? await defaultAnyaGgufSearchRoots()
+            : const <Directory>[]),
+  );
+  if (path == null) return const NoopPlanRepairPort();
+  final binder = bindModel ?? bindAnyaGgufJni;
+  return await binder(path) ?? const NoopPlanRepairPort();
+}
+
+/// Pixel JNI load. Desktop/web callers get null → no-op this slice.
+Future<PlanRepairPort?> bindAnyaGgufJni(String modelPath) async {
+  if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
+    return null;
+  }
+  try {
+    final jni = LlamaController();
+    await jni.loadModel(modelPath: modelPath, contextSize: 2048);
+    return GgufPlanRepairPort(
+      GgufCompletionClient(jni: jni, jniIsLoaded: () => true),
+    );
+  } on Object {
+    return null;
+  }
+}

--- a/app/lib/anya/anya_plan_repair_factory_stub.dart
+++ b/app/lib/anya/anya_plan_repair_factory_stub.dart
@@ -1,0 +1,6 @@
+import 'package:feature_anya/feature_anya.dart';
+
+/// Web / no-`dart:io` Anya shell: Review stays heuristic.
+Future<PlanRepairPort> createAnyaPlanRepairPort() async {
+  return const NoopPlanRepairPort();
+}

--- a/app/lib/anya/gguf_plan_repair_port.dart
+++ b/app/lib/anya/gguf_plan_repair_port.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:core_completion/core_completion.dart';
+import 'package:feature_anya/feature_anya.dart';
+import 'package:feature_anya_core/feature_anya_core.dart';
+
+/// Anya-shell [PlanRepairPort] over a shared [CompletionClient].
+///
+/// Lives in the flavor, not `feature_anya`, so llama/`core_completion` stay
+/// out of the presentation package.
+class GgufPlanRepairPort implements PlanRepairPort {
+  const GgufPlanRepairPort(this._completion, {this.maxTokens = 2048});
+
+  final CompletionClient _completion;
+  final int maxTokens;
+
+  static const _requiredKeys = ['id', 'title', 'source', 'phases'];
+
+  @override
+  bool get isAvailable => _completion.isAvailable;
+
+  @override
+  Stream<String> repair(DietProgram draft) {
+    return _completion.generate(
+      prompt: _prompt(draft),
+      grammar: jsonObjectGbnf(requiredKeys: _requiredKeys),
+      maxTokens: maxTokens,
+    );
+  }
+
+  String _prompt(DietProgram draft) {
+    return 'You repair a nutrition-plan JSON object.\n'
+        'Return only one JSON object matching the input schema.\n'
+        'Join split food names that belong together.\n'
+        'Drop rows whose names are only meal labels '
+        '(Breakfast, Lunch, Dinner, Evening, Snack, Early morning, '
+        'Mid Morning).\n'
+        'Keep every quantityRaw exactly as given. Do not invent calories, '
+        'BMI, units, or medical advice.\n'
+        'If a quantity looks unclear (for example "1k"), keep it unchanged.\n'
+        '\n'
+        'DRAFT:\n'
+        '${jsonEncode(draft.toJson())}\n';
+  }
+}

--- a/app/lib/main_anya.dart
+++ b/app/lib/main_anya.dart
@@ -8,6 +8,9 @@
 /// cd app
 /// cp pubspec_anya.yaml pubspec.yaml && flutter pub get
 /// flutter run -d chrome -t lib/main_anya.dart --dart-define=APP_VARIANT=anya
+/// # Pixel with a local GGUF:
+/// flutter run -d <pixel> -t lib/main_anya.dart --dart-define=APP_VARIANT=anya \
+///   --dart-define=ANYA_GGUF_PATH=/path/to/model.gguf
 /// ```
 library;
 
@@ -20,6 +23,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'anya/anya_plan_repair_factory_stub.dart'
+    if (dart.library.io) 'anya/anya_plan_repair_factory_io.dart'
+    as anya_repair;
 import 'core/pro/pro_bootstrap_runner.dart';
 
 void main() {
@@ -41,12 +47,14 @@ void main() {
     composeApp: () async {
       registry = buildAnyaModuleRegistry();
       final prefs = await SharedPreferences.getInstance();
+      final repairPort = await anya_repair.createAnyaPlanRepairPort();
       return AiroAnyaApp(
         registry: registry,
         repository: SecureAnyaRepository(
           secrets: FlutterAnyaSecretStore(),
           plaintextFallback: prefs,
         ),
+        planRepairPort: repairPort,
       );
     },
     afterRunApp: () {
@@ -71,10 +79,12 @@ class AiroAnyaApp extends StatefulWidget {
     super.key,
     required this.registry,
     required this.repository,
+    this.planRepairPort = const NoopPlanRepairPort(),
   });
 
   final ModuleRegistry registry;
   final AnyaRepository repository;
+  final PlanRepairPort planRepairPort;
 
   @override
   State<AiroAnyaApp> createState() => _AiroAnyaAppState();
@@ -98,7 +108,7 @@ class _AiroAnyaAppState extends State<AiroAnyaApp> {
       overrides: [
         ...widget.registry.allProviderOverrides,
         anyaRepositoryProvider.overrideWithValue(widget.repository),
-        planRepairPortProvider.overrideWithValue(const NoopPlanRepairPort()),
+        planRepairPortProvider.overrideWithValue(widget.planRepairPort),
       ],
       child: MaterialApp.router(
         title: 'Anya',

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -467,6 +467,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  core_completion:
+    dependency: "direct main"
+    description:
+      path: "../packages/core_completion"
+      relative: true
+    source: path
+    version: "0.0.1"
   core_data:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -84,6 +84,10 @@ dependencies:
     path: ../packages/core_ui
   core_ai:
     path: ../packages/core_ai
+  # Phone analyze compiles lib/main_anya.dart. The Anya flavor is what
+  # actually loads a GGUF; llama is already on this graph via Mind.
+  core_completion:
+    path: ../packages/core_completion
   core_workers:
     path: ../packages/core_workers
   core_auth:

--- a/app/pubspec_anya.yaml
+++ b/app/pubspec_anya.yaml
@@ -27,6 +27,10 @@ dependencies:
     path: ../packages/core_product_shell
   core_workers:
     path: ../packages/core_workers
+  core_completion:
+    path: ../packages/core_completion
+  llama_flutter_android: ^0.2.6
+  path_provider: ^2.1.6
   feature_anya:
     path: ../packages/feature_anya
   feature_anya_core:

--- a/app/test/anya/anya_plan_repair_factory_test.dart
+++ b/app/test/anya/anya_plan_repair_factory_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:airo_app/anya/anya_gguf_path.dart';
+import 'package:airo_app/anya/anya_plan_repair_factory_io.dart';
+import 'package:airo_app/anya/gguf_plan_repair_port.dart';
+import 'package:core_completion/core_completion.dart';
+import 'package:feature_anya/feature_anya.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('anya_gguf_');
+  });
+
+  tearDown(() async {
+    if (tmp.existsSync()) await tmp.delete(recursive: true);
+  });
+
+  test('resolveAnyaGgufPath returns a configured file that exists', () async {
+    final file = File('${tmp.path}/model.gguf');
+    await file.writeAsString('not-a-real-model');
+
+    expect(resolveAnyaGgufPath(configuredPath: file.path), file.path);
+  });
+
+  test('resolveAnyaGgufPath is null when the configured file is missing', () {
+    expect(
+      resolveAnyaGgufPath(configuredPath: '${tmp.path}/missing.gguf'),
+      isNull,
+    );
+  });
+
+  test('resolveAnyaGgufPath finds the first gguf under search roots', () async {
+    final models = Directory('${tmp.path}/models')..createSync();
+    final file = File('${models.path}/gemma.gguf');
+    await file.writeAsString('gguf');
+
+    expect(
+      resolveAnyaGgufPath(
+        searchRoots: [Directory('${tmp.path}/empty'), models],
+      ),
+      file.path,
+    );
+  });
+
+  test('factory returns NoopPlanRepairPort when no GGUF is found', () async {
+    final port = await createAnyaPlanRepairPort(
+      configuredPath: '${tmp.path}/missing.gguf',
+      searchRoots: [tmp],
+    );
+
+    expect(port, isA<NoopPlanRepairPort>());
+    expect(port.isAvailable, isFalse);
+  });
+
+  test('factory returns NoopPlanRepairPort when bind fails', () async {
+    final file = File('${tmp.path}/model.gguf');
+    await file.writeAsString('gguf');
+
+    final port = await createAnyaPlanRepairPort(
+      configuredPath: file.path,
+      bindModel: (_) async => null,
+    );
+
+    expect(port, isA<NoopPlanRepairPort>());
+  });
+
+  test('factory wraps an injected available CompletionClient', () async {
+    final port = await createAnyaPlanRepairPort(
+      completion: FakeCompletionClient(tokens: const ['{}']),
+    );
+
+    expect(port, isA<GgufPlanRepairPort>());
+    expect(port.isAvailable, isTrue);
+  });
+
+  test('factory returns the bound port when bind succeeds', () async {
+    final file = File('${tmp.path}/model.gguf');
+    await file.writeAsString('gguf');
+    final bound = GgufPlanRepairPort(FakeCompletionClient());
+
+    final port = await createAnyaPlanRepairPort(
+      configuredPath: file.path,
+      bindModel: (path) async {
+        expect(path, file.path);
+        return bound;
+      },
+    );
+
+    expect(identical(port, bound), isTrue);
+  });
+}

--- a/app/test/anya/gguf_plan_repair_port_test.dart
+++ b/app/test/anya/gguf_plan_repair_port_test.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+import 'package:airo_app/anya/gguf_plan_repair_port.dart';
+import 'package:core_completion/core_completion.dart';
+import 'package:feature_anya/feature_anya.dart';
+import 'package:feature_anya_core/feature_anya_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _draft = DietProgram(
+  id: 'imported',
+  title: 'Clinic plan.pdf',
+  source: ProgramSource.imported,
+  phases: [
+    DietPhase(
+      id: 'p1',
+      name: 'Phase',
+      days: [
+        DietDay(
+          dayNumber: 7,
+          meals: [
+            MealSlot(
+              type: MealType.breakfast,
+              time: '10:00',
+              items: [FoodItem(name: 'veg poha', quantityRaw: '1k')],
+            ),
+          ],
+        ),
+      ],
+    ),
+  ],
+);
+
+void main() {
+  test('GgufPlanRepairPort is available when the completion client is', () {
+    final available = GgufPlanRepairPort(FakeCompletionClient());
+    final unavailable = GgufPlanRepairPort(
+      FakeCompletionClient(available: false),
+    );
+
+    expect(available.isAvailable, isTrue);
+    expect(unavailable.isAvailable, isFalse);
+    expect(unavailable, isA<PlanRepairPort>());
+  });
+
+  test('repair forwards draft JSON, JSON-object grammar, and tokens', () async {
+    final client = FakeCompletionClient(tokens: const ['{"id":', '"x"}']);
+    final port = GgufPlanRepairPort(client, maxTokens: 2048);
+
+    expect(await port.repair(_draft).toList(), ['{"id":', '"x"}']);
+    expect(client.lastPrompt, contains(jsonEncode(_draft.toJson())));
+    expect(client.lastPrompt, contains('1k'));
+    expect(client.lastGrammar, contains('root ::= object'));
+    expect(client.lastGrammar, contains('"id"'));
+    expect(client.lastGrammar, contains('"title"'));
+    expect(client.lastGrammar, contains('"source"'));
+    expect(client.lastGrammar, contains('"phases"'));
+    expect(client.lastMaxTokens, 2048);
+  });
+}

--- a/app/test/main_anya_shell_test.dart
+++ b/app/test/main_anya_shell_test.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:airo_app/main_anya.dart';
 import 'package:core_product_shell/core_product_shell.dart';
-import 'package:feature_anya/feature_anya.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
@@ -29,5 +28,19 @@ void main() {
     expect(registry.moduleIds, ['anya']);
     final paths = registry.allRoutes.whereType<GoRoute>().map((r) => r.path);
     expect(paths, contains('/'));
+  });
+
+  test('feature_anya stays free of completion and Mind', () {
+    final pubspec = File(
+      '../packages/feature_anya/pubspec.yaml',
+    ).readAsStringSync();
+    final core = File(
+      '../packages/feature_anya_core/pubspec.yaml',
+    ).readAsStringSync();
+    for (final body in [pubspec, core]) {
+      expect(body, isNot(contains('core_completion')));
+      expect(body, isNot(contains('llama_flutter_android')));
+      expect(body, isNot(contains('feature_mind')));
+    }
   });
 }

--- a/docs/superpowers/plans/2026-09-12-anya-gguf-plan-repair.md
+++ b/docs/superpowers/plans/2026-09-12-anya-gguf-plan-repair.md
@@ -1,0 +1,50 @@
+# Anya GGUF PlanRepairPort Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (this session: inline). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind Anya import Review to on-device GGUF via `GgufPlanRepairPort` in the Anya shell, keeping `feature_anya` free of llama.
+
+**Architecture:** Adapter in `app/lib/anya/` wraps `CompletionClient`. Conditional import: web stub always no-op; IO factory resolves a `.gguf` path and loads Android JNI. Session already buffers/validates/merges.
+
+**Tech Stack:** Dart/Flutter, `core_completion`, `llama_flutter_android` (Anya flavor), `path_provider`, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-09-12-anya-gguf-plan-repair-design.md` (#1991)
+
+---
+
+## File map
+
+Create:
+- `app/lib/anya/gguf_plan_repair_port.dart`
+- `app/lib/anya/anya_gguf_path.dart`
+- `app/lib/anya/anya_plan_repair_factory_stub.dart`
+- `app/lib/anya/anya_plan_repair_factory_io.dart`
+- `app/test/anya/gguf_plan_repair_port_test.dart`
+- `app/test/anya/anya_plan_repair_factory_test.dart`
+
+Modify:
+- `app/lib/main_anya.dart` — factory + `AiroAnyaApp.planRepairPort`
+- `app/pubspec_anya.yaml` — `core_completion`, `path_provider`
+- `app/pubspec.yaml` — `core_completion` so `main_anya.dart` analyzes in the phone package
+
+Do not modify `packages/feature_anya`, `packages/feature_anya_core`.
+
+---
+
+### Task 1: GgufPlanRepairPort
+
+- [x] Failing tests: available/unavailable, prompt contains draft JSON, grammar required keys, tokens forwarded
+- [x] Implement port
+- [x] `flutter test test/anya/gguf_plan_repair_port_test.dart`
+
+### Task 2: Path + factory
+
+- [x] Failing tests: configured existing file; missing file → null; searchRoots first `*.gguf`; factory no path / bind fail → `NoopPlanRepairPort`; injected available client → `GgufPlanRepairPort`
+- [x] Implement path helper + IO factory + web stub
+- [x] Tests pass
+
+### Task 3: Wire shell
+
+- [x] `createAnyaPlanRepairPort()` in `composeApp`; `AiroAnyaApp` override uses injected port (default no-op)
+- [x] pubspecs
+- [x] `flutter analyze` on touched files; existing `main_anya_shell_test` still passes

--- a/docs/superpowers/specs/2026-09-12-anya-gguf-plan-repair-design.md
+++ b/docs/superpowers/specs/2026-09-12-anya-gguf-plan-repair-design.md
@@ -1,0 +1,51 @@
+# Anya GGUF `PlanRepairPort` adapter
+
+**Date:** 2026-09-12
+**Status:** Approved for implementation (this slice)
+**Issue:** [#1991](https://github.com/DevelopersCoffee/airo/issues/1991)
+**Owner:** Anya / Nutrition Agent (shell wiring). Shared generate seam stays Framework Agent (`core_completion`).
+**Depends on:** [core_completion](./2026-09-12-core-completion-design.md) (merged), [Anya import repair](./2026-09-12-anya-import-repair-design.md)
+
+## Problem
+
+`PlanRepairPort` is no-op. Pixel can run a local GGUF; Chrome cannot. Review stays heuristic unless the Anya shell binds `CompletionClient` without pulling Mind UI or putting llama inside `feature_anya`.
+
+## This slice
+
+1. `GgufPlanRepairPort` in the Anya **app shell** (`app/lib/anya/`), wrapping `CompletionClient`. Prompt = wellness repair instructions + `jsonEncode(draft.toJson())`. Grammar = `jsonObjectGbnf(requiredKeys: ['id', 'title', 'source', 'phases'])`.
+2. Factory: web or no model file → `NoopPlanRepairPort`. Android with a loadable `*.gguf` → `GgufPlanRepairPort(GgufCompletionClient(jni: …))`.
+3. `pubspec_anya.yaml` depends on `core_completion` (llama enters the **flavor**, never `feature_anya` / `feature_anya_core`).
+4. `AiroAnyaApp` overrides `planRepairPortProvider` with the factory result. Session pipeline unchanged (buffer, validate, merge, fallback).
+
+## Non-goals
+
+- Chrome Prompt API / Gemini Nano
+- Desktop FRB / `airo_mind_llama` in Anya (Pixel JNI only this slice)
+- `loadModel` in `core_completion`
+- Teaching JNI a grammar sampler
+- Pixel metrics collection UI (still tracked on #1991)
+- Calories, OCR, Anya AI tab, super-app registration
+
+## Binding
+
+- `feature_anya` / `feature_anya_core`: no `core_completion`, no llama, no `feature_mind`.
+- Discover a file via `--dart-define=ANYA_GGUF_PATH=` or the first `*.gguf` under app support `models/`, app support, or documents. Missing file → no-op (`isAvailable == false`, Review idle).
+- JNI `generate` still has no `grammar` parameter; pass grammar into `CompletionClient.generate` anyway. Session JSON validate remains the safety net.
+- Load failures → `NoopPlanRepairPort`. Do not crash the shell.
+
+## Tests (host, no model binary)
+
+- Fake `CompletionClient`: port available; prompt contains draft JSON; grammar has required keys; tokens forwarded.
+- Unavailable client / no path / bind failure → `NoopPlanRepairPort` or `isAvailable == false`.
+- Existing Anya session tests still prove invalid JSON → `failed` + heuristic kept.
+- Web factory stub is `NoopPlanRepairPort`.
+
+## Success criteria
+
+- Chrome Review unchanged: idle, no spinner, heuristic plan.
+- Pixel with a GGUF file: `isAvailable == true`, cleaning banner, then complete or failed-with-heuristic.
+- Zero `feature_anya` → `feature_mind` / `core_completion` edges.
+
+## Rollback
+
+Revert Anya shell files and `pubspec_anya.yaml` `core_completion`. Port stays no-op.


### PR DESCRIPTION
## Summary
- Binds Anya import Review to `core_completion` in the **Anya shell** (`app/lib/anya/`): `GgufPlanRepairPort` wraps `CompletionClient` with a JSON-object GBNF and the heuristic draft as prompt.
- Chrome / missing model / failed load stay `NoopPlanRepairPort` (`isAvailable == false`, Review idle). Pixel JNI loads only when `ANYA_GGUF_PATH` or a scanned `*.gguf` exists.
- `feature_anya` / `feature_anya_core` still have zero `core_completion` / llama / `feature_mind` edges. Addresses the Anya GGUF adapter slice of #1991 (Chrome Prompt API / Nano and Pixel metrics remain).

Spec: `docs/superpowers/specs/2026-09-12-anya-gguf-plan-repair-design.md`.

## Test plan
- [x] `cd app && flutter test test/anya test/main_anya_shell_test.dart` (12 passed)
- [x] `cd app && flutter analyze lib/anya lib/main_anya.dart test/anya test/main_anya_shell_test.dart` (clean)
- [ ] Chrome: `cp pubspec_anya.yaml pubspec.yaml && flutter pub get && flutter run -d chrome -t lib/main_anya.dart --dart-define=APP_VARIANT=anya` — import/paste still heuristic-only, no cleaning spinner
- [ ] Pixel 9: same entrypoint with `--dart-define=ANYA_GGUF_PATH=/path/to/model.gguf` — cleaning banner then complete or failed-with-heuristic
- [ ] Restore `app/pubspec.yaml` from git after flavor swap


Made with [Cursor](https://cursor.com)