### PR TITLE
fix(iptv): reject Google DAI URLs with a clear error

### DIFF
--- a/docs/features/media-hub/CAST_RECEIVER_COMPATIBILITY.md
+++ b/docs/features/media-hub/CAST_RECEIVER_COMPATIBILITY.md
@@ -18,6 +18,13 @@ Supported V1 media:
 - public progressive MP4 streams
 - streams reachable by the receiver device itself
 
+Unsupported V1 media:
+
+- Google DAI (`dai.google.com`) and other ad-insertion stream-request APIs.
+  These are not playable manifests. Aika Stream does not run IMA/DAI stitching;
+  Cast and local playback show a clear unsupported-source error instead of
+  sending the API URL to the player or receiver.
+
 Unsupported V1 receivers:
 
 - MacBook as a generic Google Cast receiver

--- a/packages/feature_iptv/test/iptv/iptv_cast_media_adapter_test.dart
+++ b/packages/feature_iptv/test/iptv/iptv_cast_media_adapter_test.dart
@@ -106,6 +106,22 @@ void main() {
     expect(result.request!.imageUrl, isNull);
   });
 
+  test('rejects Google DAI stream-request URLs with a clear error', () {
+    final result = adapter.toCastRequest(
+      channel(
+        streamUrl:
+            'https://dai.google.com/linear/hls/event/c-rArva4ShKVIAkNfy6HUQ/master.m3u8',
+      ),
+    );
+
+    expect(result.isCastable, false);
+    expect(result.error!.code, AiroCastErrorCode.unsupportedStream);
+    expect(
+      result.error!.message,
+      contains('ad-insertion support we do not provide'),
+    );
+  });
+
   test('rejects unknown stream formats', () {
     final result = adapter.toCastRequest(
       channel(streamUrl: 'https://example.com/playlist.ts'),

--- a/packages/feature_iptv/test/iptv/iptv_cast_notifier_test.dart
+++ b/packages/feature_iptv/test/iptv/iptv_cast_notifier_test.dart
@@ -52,6 +52,31 @@ void main() {
     );
   });
 
+  test('rejects a DAI channel without connecting to Cast', () async {
+    final fake = FakeAiroCastController(devices: const [tv]);
+    final container = containerWith(fake);
+
+    await container
+        .read(iptvCastProvider.notifier)
+        .castChannelToDevice(
+          channel: channel().copyWith(
+            streamUrl:
+                'https://dai.google.com/linear/v1/hls/event/c-rArva4ShKVIAkNfy6HUQ/stream',
+          ),
+          device: tv,
+        );
+
+    expect(fake.recordedActions, isEmpty);
+    expect(
+      container.read(iptvCastProvider).lastError?.code,
+      AiroCastErrorCode.unsupportedStream,
+    );
+    expect(
+      container.read(iptvCastProvider).lastError?.message,
+      contains('ad-insertion support we do not provide'),
+    );
+  });
+
   test('stores unsupported stream error without connecting', () async {
     final fake = FakeAiroCastController(devices: const [tv]);
     final container = containerWith(fake);

--- a/packages/platform_channels/lib/src/security/playlist_url_policy.dart
+++ b/packages/platform_channels/lib/src/security/playlist_url_policy.dart
@@ -4,6 +4,11 @@ class AiroPlaylistUrlPolicy {
 
   static const int maxShareStreamUrlLength = 2048;
 
+  /// TV-safe copy when a playlist URL is a DAI/SSAI stream-request API,
+  /// not a playable HLS/DASH manifest. Keep this at or under 80 characters.
+  static const String adInsertionUnsupportedUserMessage =
+      'This source needs ad-insertion support we do not provide.';
+
   static const Set<String> _sensitiveShareQueryKeys = {
     'accesstoken',
     'apikey',
@@ -114,6 +119,37 @@ class AiroPlaylistUrlPolicy {
       allowPrivateHosts: allowPrivateHosts,
     );
   }
+
+  /// Google DAI and similar hosts are stream-request APIs, not manifests.
+  ///
+  /// Aika Stream is bring-your-own-playlist and does not run IMA/DAI
+  /// stitching. Callers should skip these URLs or surface
+  /// [adInsertionUnsupportedUserMessage] instead of handing them to a player
+  /// or Cast receiver.
+  static bool isAdInsertionApiUrl(Uri uri) {
+    final host = uri.host.trim().toLowerCase();
+    return host == 'dai.google.com' || host.endsWith('.dai.google.com');
+  }
+
+  /// [isAdInsertionApiUrl] for a raw playlist string, including exception
+  /// text that embeds the URL.
+  static bool isAdInsertionApiUrlString(String? value) {
+    final raw = value?.trim();
+    if (raw == null || raw.isEmpty) return false;
+
+    final parsed = Uri.tryParse(raw);
+    if (parsed != null &&
+        parsed.host.isNotEmpty &&
+        isAdInsertionApiUrl(parsed)) {
+      return true;
+    }
+
+    return _adInsertionHostInText.hasMatch(raw.toLowerCase());
+  }
+
+  static final RegExp _adInsertionHostInText = RegExp(
+    r'(?:^|[^a-z0-9.-])(?:[a-z0-9-]+\.)*dai\.google\.com(?:[^a-z0-9.-]|$)',
+  );
 
   /// Returns true for localhost, link-local, RFC1918, and other non-public
   /// address ranges that must not be fetched from playlist-derived data unless

--- a/packages/platform_channels/test/security/playlist_url_policy_test.dart
+++ b/packages/platform_channels/test/security/playlist_url_policy_test.dart
@@ -2,6 +2,59 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:platform_channels/platform_channels.dart';
 
 void main() {
+  group('isAdInsertionApiUrl', () {
+    test('detects Google DAI stream-request and master hosts', () {
+      const samples = [
+        'https://dai.google.com/linear/v1/hls/event/c-rArva4ShKVIAkNfy6HUQ/stream',
+        'https://dai.google.com/linear/hls/event/c-rArva4ShKVIAkNfy6HUQ/master.m3u8',
+        'https://dai.google.com/ondemand/v1/dash/content/123/vid/abc/stream',
+        'http://preview.dai.google.com/linear/hls/event/test/master.m3u8',
+      ];
+
+      for (final sample in samples) {
+        expect(
+          AiroPlaylistUrlPolicy.isAdInsertionApiUrlString(sample),
+          isTrue,
+          reason: sample,
+        );
+        expect(
+          AiroPlaylistUrlPolicy.isAdInsertionApiUrl(Uri.parse(sample)),
+          isTrue,
+          reason: sample,
+        );
+      }
+    });
+
+    test('does not flag ordinary HLS or lookalike hosts', () {
+      const samples = [
+        'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8',
+        'https://media.example.com/live/master.m3u8',
+        'https://notdai.google.com/linear/hls/event/x/master.m3u8',
+        'https://dai.google.com.evil.example/master.m3u8',
+        '',
+        '   ',
+      ];
+
+      for (final sample in samples) {
+        expect(
+          AiroPlaylistUrlPolicy.isAdInsertionApiUrlString(sample),
+          isFalse,
+          reason: sample,
+        );
+      }
+    });
+
+    test('detects a DAI host embedded in an engine exception string', () {
+      expect(
+        AiroPlaylistUrlPolicy.isAdInsertionApiUrlString(
+          'PlatformException(VideoError, Failed to load '
+          'https://dai.google.com/linear/v1/hls/event/x/stream, null)',
+        ),
+        isTrue,
+      );
+    });
+  });
+
   group('validateShareStreamUrl', () {
     test('allows a public credential-free HLS stream', () {
       final result = AiroPlaylistUrlPolicy.validateShareStreamUrl(

--- a/packages/platform_media/lib/src/streaming_error_diagnostic_mapping.dart
+++ b/packages/platform_media/lib/src/streaming_error_diagnostic_mapping.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:platform_channels/platform_channels.dart';
 import 'package:platform_player/platform_player.dart';
 
 /// Maps a raw playback exception/message from [VideoPlayerController] or the
@@ -22,7 +23,17 @@ AiroPlaybackDiagnostic mapStreamingErrorToDiagnostic(Object error) {
     );
   }
 
-  final message = error.toString().toLowerCase();
+  final raw = error.toString();
+  if (AiroPlaylistUrlPolicy.isAdInsertionApiUrlString(raw) ||
+      raw.toLowerCase().contains('ad_insertion_unsupported')) {
+    return mapper.map(
+      const AiroPlaybackFailureEvent(
+        overrideCode: AiroPlaybackDiagnosticCode.adInsertionUnsupported,
+      ),
+    );
+  }
+
+  final message = raw.toLowerCase();
 
   if (_containsCodecSignal(message)) {
     return mapper.map(

--- a/packages/platform_media/lib/src/video_player_streaming_service.dart
+++ b/packages/platform_media/lib/src/video_player_streaming_service.dart
@@ -203,6 +203,14 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
       )..start(preferredSourceId: _preferredSourceId(channel));
     }
 
+    if (_failoverController!.state.currentSource == null) {
+      await _handleError(
+        'ad_insertion_unsupported',
+        overrideCode: AiroPlaybackDiagnosticCode.adInsertionUnsupported,
+      );
+      return;
+    }
+
     // F7.1: preserveFailover means this call continues an in-progress
     // session (stall-triggered switch, or retry() advancing to the next
     // source) — the existing collector keeps accumulating. A fresh call
@@ -330,6 +338,9 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
       ..sort(compareChannelStreamSources);
     for (var index = 0; index < rankedSources.length; index++) {
       final stream = rankedSources[index];
+      if (AiroPlaylistUrlPolicy.isAdInsertionApiUrlString(stream.url)) {
+        continue;
+      }
       if (!seenUrls.add(stream.url)) continue;
       sources.add(
         AiroFailoverSource(
@@ -355,7 +366,8 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
         ),
       );
     }
-    if (seenUrls.add(channel.streamUrl)) {
+    if (!AiroPlaylistUrlPolicy.isAdInsertionApiUrlString(channel.streamUrl) &&
+        seenUrls.add(channel.streamUrl)) {
       sources.add(
         AiroFailoverSource(
           sourceId: 'default',
@@ -373,6 +385,9 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
       var rank = 1;
       for (final entry in qualityUrls.entries) {
         if (entry.value == channel.streamUrl) continue;
+        if (AiroPlaylistUrlPolicy.isAdInsertionApiUrlString(entry.value)) {
+          continue;
+        }
         if (!seenUrls.add(entry.value)) continue;
         sources.add(
           AiroFailoverSource(
@@ -713,8 +728,14 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
   /// advance to the next source) and [_handleError] (which renders it).
   AiroPlaybackDiagnostic _diagnosticFor(
     String message,
-    AiroPlaybackError? engineError,
-  ) {
+    AiroPlaybackError? engineError, {
+    AiroPlaybackDiagnosticCode? overrideCode,
+  }) {
+    if (overrideCode != null) {
+      return const AiroPlaybackDiagnosticMapper().map(
+        AiroPlaybackFailureEvent(overrideCode: overrideCode),
+      );
+    }
     return engineError != null
         ? const AiroPlaybackDiagnosticMapper().map(
             AiroPlaybackFailureEvent(
@@ -728,6 +749,7 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
   Future<void> _handleError(
     String message, {
     AiroPlaybackError? engineError,
+    AiroPlaybackDiagnosticCode? overrideCode,
   }) async {
     if (_isHandlingError || _state.playbackState == PlaybackState.error) {
       return;
@@ -737,9 +759,6 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     final newRetryCount = _state.retryCount + 1;
 
     final retriesExhausted = newRetryCount > _config.maxRetries;
-    final userMessage = retriesExhausted
-        ? _deadStreamTerminalMessage
-        : 'Playback failed: $message';
 
     // CV-001: structured, user-safe diagnostic alongside the legacy
     // errorMessage. UI prefers this when present; retry stays manual here
@@ -755,8 +774,19 @@ class VideoPlayerStreamingService implements IPTVStreamingService {
     // this, every engine code except codec_unsupported (which happens to
     // match the 'codec' substring check) fell through to a generic
     // `unknown` diagnostic.
-    final diagnostic = _diagnosticFor(message, engineError);
-    final terminalDiagnostic = retriesExhausted
+    final diagnostic = _diagnosticFor(
+      message,
+      engineError,
+      overrideCode: overrideCode,
+    );
+    final keepDiagnosticCopy =
+        diagnostic.code == AiroPlaybackDiagnosticCode.adInsertionUnsupported;
+    final userMessage = keepDiagnosticCopy
+        ? diagnostic.userMessage
+        : retriesExhausted
+        ? _deadStreamTerminalMessage
+        : 'Playback failed: $message';
+    final terminalDiagnostic = retriesExhausted && !keepDiagnosticCopy
         ? AiroPlaybackDiagnostic(
             code: diagnostic.code,
             severity: diagnostic.severity,

--- a/packages/platform_media/test/streaming_error_diagnostic_mapping_test.dart
+++ b/packages/platform_media/test/streaming_error_diagnostic_mapping_test.dart
@@ -52,11 +52,45 @@ void main() {
       expect(diagnostic.retryEligible, isFalse);
     });
 
+    test('maps an embedded dai.google.com URL to ad-insertion unsupported', () {
+      final diagnostic = mapStreamingErrorToDiagnostic(
+        Exception(
+          'Failed to load https://dai.google.com/linear/v1/hls/event/x/stream',
+        ),
+      );
+
+      expect(
+        diagnostic.code,
+        AiroPlaybackDiagnosticCode.adInsertionUnsupported,
+      );
+      expect(diagnostic.retryEligible, isFalse);
+      expect(diagnostic.userMessage, isNot(contains('dai.google')));
+    });
+
+    test('maps the stable ad-insertion token from the streaming service', () {
+      final diagnostic = mapStreamingErrorToDiagnostic(
+        'ad_insertion_unsupported',
+      );
+
+      expect(
+        diagnostic.code,
+        AiroPlaybackDiagnosticCode.adInsertionUnsupported,
+      );
+    });
+
     test('falls back to an unknown retryable diagnostic for opaque errors', () {
       final diagnostic = mapStreamingErrorToDiagnostic('boom');
 
       expect(diagnostic.code, AiroPlaybackDiagnosticCode.unknown);
       expect(diagnostic.retryEligible, isTrue);
+    });
+
+    test('leaves ordinary HLS failures on the existing unknown path', () {
+      final diagnostic = mapStreamingErrorToDiagnostic(
+        Exception('Failed to load https://media.example.com/live.m3u8'),
+      );
+
+      expect(diagnostic.code, AiroPlaybackDiagnosticCode.unknown);
     });
 
     test('never includes the raw error text verbatim in technical detail', () {

--- a/packages/platform_player/lib/src/models/playback_recovery_models.dart
+++ b/packages/platform_player/lib/src/models/playback_recovery_models.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:platform_channels/platform_channels.dart';
 
 import '../services/cast_log_redaction.dart';
 import 'playback_engine_models.dart';
@@ -16,6 +17,7 @@ enum AiroPlaybackDiagnosticCode {
   codecUnsupported('codec_unsupported'),
   playerInitFailed('player_init_failed'),
   sourceInvalid('source_invalid'),
+  adInsertionUnsupported('ad_insertion_unsupported'),
   unknown('unknown');
 
   const AiroPlaybackDiagnosticCode(this.stableId);
@@ -115,6 +117,12 @@ class AiroPlaybackDiagnosticMapper {
     final override = event.overrideCode;
     if (override != null) return override;
 
+    final sourceUri = event.sourceUri;
+    if (sourceUri != null &&
+        AiroPlaylistUrlPolicy.isAdInsertionApiUrl(sourceUri)) {
+      return AiroPlaybackDiagnosticCode.adInsertionUnsupported;
+    }
+
     final status = event.httpStatusCode;
     if (status != null) return _codeForHttpStatus(status);
 
@@ -166,6 +174,7 @@ class AiroPlaybackDiagnosticMapper {
       AiroPlaybackDiagnosticCode.codecUnsupported ||
       AiroPlaybackDiagnosticCode.playerInitFailed ||
       AiroPlaybackDiagnosticCode.sourceInvalid ||
+      AiroPlaybackDiagnosticCode.adInsertionUnsupported ||
       AiroPlaybackDiagnosticCode.providerAuthDenied ||
       AiroPlaybackDiagnosticCode.regionRestricted ||
       AiroPlaybackDiagnosticCode.providerNotFound =>
@@ -181,7 +190,8 @@ class AiroPlaybackDiagnosticMapper {
       AiroPlaybackDiagnosticCode.providerNotFound ||
       AiroPlaybackDiagnosticCode.codecUnsupported ||
       AiroPlaybackDiagnosticCode.playerInitFailed ||
-      AiroPlaybackDiagnosticCode.sourceInvalid => false,
+      AiroPlaybackDiagnosticCode.sourceInvalid ||
+      AiroPlaybackDiagnosticCode.adInsertionUnsupported => false,
       _ => true,
     };
   }
@@ -210,6 +220,8 @@ class AiroPlaybackDiagnosticMapper {
         'Playback could not start on this device.',
       AiroPlaybackDiagnosticCode.sourceInvalid =>
         'This channel address looks invalid. Check your playlist.',
+      AiroPlaybackDiagnosticCode.adInsertionUnsupported =>
+        AiroPlaylistUrlPolicy.adInsertionUnsupportedUserMessage,
       AiroPlaybackDiagnosticCode.unknown => 'Playback failed. Retrying…',
     };
   }

--- a/packages/platform_player/lib/src/services/flutter_chrome_cast_controller.dart
+++ b/packages/platform_player/lib/src/services/flutter_chrome_cast_controller.dart
@@ -40,6 +40,16 @@ class FlutterChromeCastController implements AiroCastController {
     defaultValue: GoogleCastDiscoveryCriteria.kDefaultApplicationId,
   );
 
+  /// Last-resort guard if a DAI URL reaches [load] without going through
+  /// [IptvCastMediaAdapter].
+  static AiroCastError? adInsertionUnsupportedError(Uri url) {
+    if (!AiroPlaylistUrlPolicy.isAdInsertionApiUrl(url)) return null;
+    return const AiroCastError(
+      code: AiroCastErrorCode.unsupportedStream,
+      message: AiroPlaylistUrlPolicy.adInsertionUnsupportedUserMessage,
+    );
+  }
+
   final _discoveryController =
       StreamController<AiroCastDiscoveryState>.broadcast();
   final _sessionController =
@@ -281,6 +291,12 @@ class FlutterChromeCastController implements AiroCastController {
           ),
         ),
       );
+      return;
+    }
+
+    final adInsertionError = adInsertionUnsupportedError(request.url);
+    if (adInsertionError != null) {
+      _setSession(AiroCastSessionSnapshot.failed(adInsertionError));
       return;
     }
 

--- a/packages/platform_player/lib/src/services/iptv_cast_media_adapter.dart
+++ b/packages/platform_player/lib/src/services/iptv_cast_media_adapter.dart
@@ -24,6 +24,12 @@ class IptvCastMediaAdapter {
       );
     }
 
+    if (AiroPlaylistUrlPolicy.isAdInsertionApiUrl(uri)) {
+      return IptvCastMediaResult.unsupported(
+        AiroPlaylistUrlPolicy.adInsertionUnsupportedUserMessage,
+      );
+    }
+
     final contentType = _contentTypeFor(uri, channel);
     if (contentType == null) {
       return IptvCastMediaResult.unsupported(

--- a/packages/platform_player/test/flutter_chrome_cast_controller_test.dart
+++ b/packages/platform_player/test/flutter_chrome_cast_controller_test.dart
@@ -26,6 +26,27 @@ void main() {
     });
   });
 
+  test('rejects Google DAI URLs before the receiver is probed', () {
+    final error = FlutterChromeCastController.adInsertionUnsupportedError(
+      Uri.parse(
+        'https://dai.google.com/linear/hls/event/c-rArva4ShKVIAkNfy6HUQ/master.m3u8',
+      ),
+    );
+
+    expect(error, isNotNull);
+    expect(error!.code, AiroCastErrorCode.unsupportedStream);
+    expect(error.message, contains('ad-insertion'));
+  });
+
+  test('allows ordinary HLS hosts through the DAI guard', () {
+    expect(
+      FlutterChromeCastController.adInsertionUnsupportedError(
+        Uri.parse('https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8'),
+      ),
+      isNull,
+    );
+  });
+
   test('maps live HLS request to Google Cast media information', () {
     final request = AiroCastMediaRequest(
       url: Uri.parse('https://example.com/channel.m3u8'),

--- a/packages/platform_player/test/playback_recovery_test.dart
+++ b/packages/platform_player/test/playback_recovery_test.dart
@@ -115,6 +115,26 @@ void main() {
       },
     );
 
+    test('maps Google DAI source URIs to a fatal ad-insertion diagnostic', () {
+      final diagnostic = mapper.map(
+        AiroPlaybackFailureEvent(
+          httpStatusCode: 404,
+          sourceUri: Uri.parse(
+            'https://dai.google.com/linear/v1/hls/event/test/stream',
+          ),
+        ),
+      );
+
+      expect(
+        diagnostic.code,
+        AiroPlaybackDiagnosticCode.adInsertionUnsupported,
+      );
+      expect(diagnostic.severity, AiroPlaybackDiagnosticSeverity.fatal);
+      expect(diagnostic.retryEligible, isFalse);
+      expect(diagnostic.userMessage, isNot(contains('dai.google')));
+      expect(diagnostic.userMessage.length, lessThanOrEqualTo(80));
+    });
+
     test('redacts credentials and query strings from technical detail', () {
       final diagnostic = mapper.map(
         AiroPlaybackFailureEvent(


### PR DESCRIPTION
## Summary
- `dai.google.com` is a Google DAI stream-request API, not a playable HLS/DASH manifest. Aika Stream is BYOC and does not run IMA/DAI stitching.
- Detect those hosts on the shared playlist URL policy, skip them in local failover (play a real HLS/DASH fallback when one exists), and fail Cast **before** connecting or probing the receiver.
- Surface a TV-safe diagnostic: "This source needs ad-insertion support we do not provide." instead of a silent player/Cast failure.

## Test plan
- [x] `flutter test` in `platform_channels` playlist URL policy
- [x] `flutter test` in `platform_player` playback recovery + Cast controller
- [x] `flutter test` in `platform_media` streaming error mapping
- [x] `flutter test` in `feature_iptv` Cast adapter + notifier (DAI URL never calls `connect`)
- [ ] Pixel / Cast: import a playlist with a `dai.google.com` URL and confirm the new error; confirm a normal HLS URL (e.g. Mux `x36xhzz`) still plays

Owner: Media Intelligence Architect. Reviewers: Chief Architect, Platform Architect, Chief QA Officer.


Made with [Cursor](https://cursor.com)