### PR TITLE
docs(tv): publish Aika Stream app-ads.txt

### DIFF
--- a/docs/aika-stream/app-ads.txt
+++ b/docs/aika-stream/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-7741544685082785, DIRECT, f08c47fec0942fa0

--- a/docs/app-ads.txt
+++ b/docs/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-7741544685082785, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- Publish the AdMob authorized-seller line at the Aika Stream site path the Play listing already uses: `https://developerscoffee.github.io/airo/aika-stream/app-ads.txt`
- Also serve the same file at `/airo/app-ads.txt` so crawlers that use the repo Pages root still succeed.

## Test plan
- [ ] After merge, `curl -s https://developerscoffee.github.io/airo/aika-stream/app-ads.txt` returns the `google.com, pub-7741544685082785, DIRECT, ...` line
- [ ] Confirm it is `text/plain`, not an HTML 404


Made with [Cursor](https://cursor.com)